### PR TITLE
ICLM-26: Eligibility mappings

### DIFF
--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/model/InsurancePolicy.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/model/InsurancePolicy.java
@@ -42,6 +42,10 @@ public class InsurancePolicy extends AbstractBaseOpenmrsData {
 	@Column(name = "expiry_date")
 	private Date expiryDate;
 
+	@Basic
+	@Column(name = "policy_number")
+	private String policyNumber;
+
 	@ManyToOne
 	@Cascade(CascadeType.SAVE_UPDATE)
 	@JoinColumn(name = "patient", nullable = false)
@@ -64,12 +68,13 @@ public class InsurancePolicy extends AbstractBaseOpenmrsData {
 	 * @param status - the policy status
 	 */
 	public InsurancePolicy(Date startDate, Date expiryDate, Patient patient,
-			InsurancePolicyStatus status) {
+			InsurancePolicyStatus status, String policyNumber) {
 		super();
 		this.startDate = startDate == null ? null : (Date) startDate.clone();
 		this.expiryDate = expiryDate == null ? null : (Date) expiryDate.clone();
 		this.patient = patient;
 		this.status = status;
+		this.policyNumber = policyNumber;
 	}
 
 	@Override
@@ -96,6 +101,14 @@ public class InsurancePolicy extends AbstractBaseOpenmrsData {
 
 	public void setExpiryDate(Date expiryDate) {
 		this.expiryDate = expiryDate == null ? null : (Date) expiryDate.clone();
+	}
+
+	public String getPolicyNumber() {
+		return policyNumber;
+	}
+
+	public void setPolicyNumber(String policyNumber) {
+		this.policyNumber = policyNumber;
 	}
 
 	public Patient getPatient() {

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/InsurancePolicyService.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/InsurancePolicyService.java
@@ -1,6 +1,16 @@
 package org.openmrs.module.insuranceclaims.api.service;
 
+import org.hl7.fhir.dstu3.model.EligibilityResponse;
+import org.hl7.fhir.dstu3.model.Reference;
 import org.openmrs.module.insuranceclaims.api.model.InsurancePolicy;
 
+import java.util.Date;
+
 public interface InsurancePolicyService extends OpenmrsDataService<InsurancePolicy> {
+
+    InsurancePolicy generateInsurancePolicy(EligibilityResponse response);
+
+    String getPolicyIdFromContractReference(Reference contract);
+
+    Date getExpireDateFromContractReference(Reference contract);
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/FHIREligibilityService.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/FHIREligibilityService.java
@@ -1,0 +1,18 @@
+package org.openmrs.module.insuranceclaims.api.service.fhir;
+
+import org.hl7.fhir.dstu3.model.EligibilityRequest;
+import org.hl7.fhir.dstu3.model.EligibilityResponse;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.openmrs.module.insuranceclaims.api.model.InsurancePolicy;
+
+import java.util.Date;
+
+public interface FHIREligibilityService {
+    EligibilityRequest generateEligibilityRequest(String policyId);
+
+    InsurancePolicy generateInsurancePolicy(EligibilityResponse response);
+
+    String getPolicyIdFromContractReference(Reference contract);
+
+    Date getExpireDateFromContractReference(Reference contract);
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/FHIREligibilityService.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/FHIREligibilityService.java
@@ -1,18 +1,7 @@
 package org.openmrs.module.insuranceclaims.api.service.fhir;
 
 import org.hl7.fhir.dstu3.model.EligibilityRequest;
-import org.hl7.fhir.dstu3.model.EligibilityResponse;
-import org.hl7.fhir.dstu3.model.Reference;
-import org.openmrs.module.insuranceclaims.api.model.InsurancePolicy;
-
-import java.util.Date;
 
 public interface FHIREligibilityService {
     EligibilityRequest generateEligibilityRequest(String policyId);
-
-    InsurancePolicy generateInsurancePolicy(EligibilityResponse response);
-
-    String getPolicyIdFromContractReference(Reference contract);
-
-    Date getExpireDateFromContractReference(Reference contract);
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/impl/FHIREligibilityServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/impl/FHIREligibilityServiceImpl.java
@@ -1,0 +1,69 @@
+package org.openmrs.module.insuranceclaims.api.service.fhir.impl;
+
+import ca.uhn.fhir.util.DateUtils;
+import org.hl7.fhir.dstu3.model.EligibilityRequest;
+import org.hl7.fhir.dstu3.model.EligibilityResponse;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.openmrs.module.fhir.api.util.FHIRConstants;
+import org.openmrs.module.insuranceclaims.api.model.InsurancePolicy;
+import org.openmrs.module.insuranceclaims.api.model.InsurancePolicyStatus;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIREligibilityService;
+
+import java.util.Date;
+
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.IdentifierUtil.buildReference;
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.CONTRACT_EXPIRE_DATE_ORDINAL;
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.CONTRACT_POLICY_ID_ORDINAL;
+
+public class FHIREligibilityServiceImpl implements FHIREligibilityService {
+
+    @Override
+    public EligibilityRequest generateEligibilityRequest(String  policyId) {
+        EligibilityRequest request = new EligibilityRequest();
+        Reference patient = buildReference(FHIRConstants.PATIENT, policyId);
+        request.setPatient(patient);
+
+        return request;
+    }
+
+    @Override
+    public InsurancePolicy generateInsurancePolicy(EligibilityResponse response) {
+        Reference contract = response.getInsuranceFirstRep().getContract();
+        InsurancePolicy policy = new InsurancePolicy();
+
+        Date expireDate = getExpireDateFromContractReference(contract);
+        policy.setExpiryDate(expireDate);
+        policy.setStatus(getPolicyStatus(policy));
+        policy.setPolicyNumber(getPolicyIdFromContractReference(contract));
+
+        return policy;
+    }
+
+    public String getPolicyIdFromContractReference(Reference contract) {
+        return getElementFromContract(contract.getReference(), CONTRACT_POLICY_ID_ORDINAL);
+    }
+
+    public Date getExpireDateFromContractReference(Reference contract) {
+        String  dateString = getElementFromContract(contract.getReference(), CONTRACT_EXPIRE_DATE_ORDINAL);
+        return DateUtils.parseDate(dateString);
+    }
+
+    private String getElementFromContract(String contract, int ordinal) {
+        String[] contractParts = splitContract(contract);
+        return contractParts[ordinal];
+    }
+
+    private String[] splitContract(String contract) {
+        //Contract should have format: "Contract/policyId/expireDate
+        return contract.split("/");
+    }
+
+    private InsurancePolicyStatus getPolicyStatus(InsurancePolicy policy) {
+        Date policyExpireDate = policy.getExpiryDate();
+        return isPolicyActive(policyExpireDate) ? InsurancePolicyStatus.ACTIVE : InsurancePolicyStatus.EXPIRED;
+    }
+
+    private boolean isPolicyActive(Date policyExpireDate) {
+        return policyExpireDate.after(new Date());
+    }
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/impl/FHIREligibilityServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/impl/FHIREligibilityServiceImpl.java
@@ -1,69 +1,20 @@
 package org.openmrs.module.insuranceclaims.api.service.fhir.impl;
 
-import ca.uhn.fhir.util.DateUtils;
 import org.hl7.fhir.dstu3.model.EligibilityRequest;
-import org.hl7.fhir.dstu3.model.EligibilityResponse;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.openmrs.module.fhir.api.util.FHIRConstants;
-import org.openmrs.module.insuranceclaims.api.model.InsurancePolicy;
-import org.openmrs.module.insuranceclaims.api.model.InsurancePolicyStatus;
 import org.openmrs.module.insuranceclaims.api.service.fhir.FHIREligibilityService;
 
-import java.util.Date;
-
 import static org.openmrs.module.insuranceclaims.api.service.fhir.util.IdentifierUtil.buildReference;
-import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.CONTRACT_EXPIRE_DATE_ORDINAL;
-import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.CONTRACT_POLICY_ID_ORDINAL;
 
 public class FHIREligibilityServiceImpl implements FHIREligibilityService {
 
     @Override
-    public EligibilityRequest generateEligibilityRequest(String  policyId) {
+    public EligibilityRequest generateEligibilityRequest(String policyId) {
         EligibilityRequest request = new EligibilityRequest();
         Reference patient = buildReference(FHIRConstants.PATIENT, policyId);
         request.setPatient(patient);
 
         return request;
-    }
-
-    @Override
-    public InsurancePolicy generateInsurancePolicy(EligibilityResponse response) {
-        Reference contract = response.getInsuranceFirstRep().getContract();
-        InsurancePolicy policy = new InsurancePolicy();
-
-        Date expireDate = getExpireDateFromContractReference(contract);
-        policy.setExpiryDate(expireDate);
-        policy.setStatus(getPolicyStatus(policy));
-        policy.setPolicyNumber(getPolicyIdFromContractReference(contract));
-
-        return policy;
-    }
-
-    public String getPolicyIdFromContractReference(Reference contract) {
-        return getElementFromContract(contract.getReference(), CONTRACT_POLICY_ID_ORDINAL);
-    }
-
-    public Date getExpireDateFromContractReference(Reference contract) {
-        String  dateString = getElementFromContract(contract.getReference(), CONTRACT_EXPIRE_DATE_ORDINAL);
-        return DateUtils.parseDate(dateString);
-    }
-
-    private String getElementFromContract(String contract, int ordinal) {
-        String[] contractParts = splitContract(contract);
-        return contractParts[ordinal];
-    }
-
-    private String[] splitContract(String contract) {
-        //Contract should have format: "Contract/policyId/expireDate
-        return contract.split("/");
-    }
-
-    private InsurancePolicyStatus getPolicyStatus(InsurancePolicy policy) {
-        Date policyExpireDate = policy.getExpiryDate();
-        return isPolicyActive(policyExpireDate) ? InsurancePolicyStatus.ACTIVE : InsurancePolicyStatus.EXPIRED;
-    }
-
-    private boolean isPolicyActive(Date policyExpireDate) {
-        return policyExpireDate.after(new Date());
     }
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/ClaimResponseUtil.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/ClaimResponseUtil.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.IdentifierUtil.buildReference;
 import static org.openmrs.module.insuranceclaims.api.service.fhir.util.IdentifierUtil.getIdentifierValueByCode;
 import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.ACCESSION_ID;
 import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.CLAIM_REFERENCE;
@@ -52,16 +53,11 @@ public final class ClaimResponseUtil {
     }
 
     public static Reference buildClaimReference(InsuranceClaim omrsClaim) {
-        Reference reference = new Reference();
-        String stringReference = CLAIM_REFERENCE + "/" + omrsClaim.getClaimCode();
-        reference.setReference(stringReference);
-        return reference;
+        return buildReference(CLAIM_REFERENCE, omrsClaim.getClaimCode());
     }
 
     public static List<Reference> buildCommunicationRequestReference(InsuranceClaim omrsClaim) {
-        Reference reference = new Reference();
-        String stringReference = COMMUNICATION_REQUEST + "/" + omrsClaim.getUuid();
-        reference.setReference(stringReference);
+        Reference reference = buildReference(COMMUNICATION_REQUEST, omrsClaim.getUuid());
         return Collections.singletonList(reference);
     }
 

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/IdentifierUtil.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/IdentifierUtil.java
@@ -49,6 +49,14 @@ public final class IdentifierUtil {
         return codeClaimIdentifier;
     }
 
+    public static Reference buildReference(String referenceType, String referenceValue) {
+        Reference reference = new Reference();
+        String stringReference = referenceType + "/" + referenceValue;
+        reference.setReference(stringReference);
+        return reference;
+    }
+
+
     public static String getIdentifierValueByCode(Claim claim, String code, List<String> errors) {
         return getClaimIdentifierValueBySystemCode(claim, code);
     }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimConstants.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimConstants.java
@@ -1,5 +1,9 @@
 package org.openmrs.module.insuranceclaims.api.service.fhir.util;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 public final class InsuranceClaimConstants {
     public static final String CATEGORY_SERVICE = "service";
     public static final String CATEGORY_ITEM = "item";
@@ -41,6 +45,8 @@ public final class InsuranceClaimConstants {
     public static final String CONTRACT = "Contract";
     public static final int CONTRACT_POLICY_ID_ORDINAL = 1;
     public static final int CONTRACT_EXPIRE_DATE_ORDINAL = 2;
+    public static final List<String> CONTRACT_DATE_PATTERN = Collections.unmodifiableList(
+            Arrays.asList("yyyy-mm-dd hh:mm:ss", "yyyy-mm-dd"));
 
     private InsuranceClaimConstants() {}
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimConstants.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimConstants.java
@@ -38,5 +38,9 @@ public final class InsuranceClaimConstants {
     public static final String GUARANTEE_ID_CATEGORY = "guarantee_id";
     public static final String EXPLANATION_CATEGORY = "explanation";
 
+    public static final String CONTRACT = "Contract";
+    public static final int CONTRACT_POLICY_ID_ORDINAL = 1;
+    public static final int CONTRACT_EXPIRE_DATE_ORDINAL = 2;
+
     private InsuranceClaimConstants() {}
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsurancePolicyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsurancePolicyServiceImpl.java
@@ -1,7 +1,63 @@
 package org.openmrs.module.insuranceclaims.api.service.impl;
 
+import ca.uhn.fhir.util.DateUtils;
+import org.hl7.fhir.dstu3.model.EligibilityResponse;
+import org.hl7.fhir.dstu3.model.Reference;
 import org.openmrs.module.insuranceclaims.api.model.InsurancePolicy;
+import org.openmrs.module.insuranceclaims.api.model.InsurancePolicyStatus;
 import org.openmrs.module.insuranceclaims.api.service.InsurancePolicyService;
 
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.CONTRACT_DATE_PATTERN;
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.CONTRACT_EXPIRE_DATE_ORDINAL;
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.CONTRACT_POLICY_ID_ORDINAL;
+
 public class InsurancePolicyServiceImpl extends BaseOpenmrsDataService<InsurancePolicy> implements InsurancePolicyService {
+
+    @Override
+    public InsurancePolicy generateInsurancePolicy(EligibilityResponse response) {
+        Reference contract = response.getInsuranceFirstRep().getContract();
+        InsurancePolicy policy = new InsurancePolicy();
+        Date expireDate = getExpireDateFromContractReference(contract);
+
+        policy.setExpiryDate(expireDate);
+        policy.setStatus(getPolicyStatus(policy));
+        policy.setPolicyNumber(getPolicyIdFromContractReference(contract));
+
+        return policy;
+    }
+
+    @Override
+    public String getPolicyIdFromContractReference(Reference contract) {
+        return getElementFromContract(contract.getReference(), CONTRACT_POLICY_ID_ORDINAL);
+    }
+
+    @Override
+    public Date getExpireDateFromContractReference(Reference contract) {
+        String dateString = getElementFromContract(contract.getReference(), CONTRACT_EXPIRE_DATE_ORDINAL);
+        String[] patterns = CONTRACT_DATE_PATTERN.toArray(new String[0]);
+        return DateUtils.parseDate(dateString,patterns);
+    }
+
+    private String getElementFromContract(String contract, int ordinal) {
+        String[] contractParts = splitContract(contract);
+        return contractParts[ordinal];
+    }
+
+    private String[] splitContract(String contract) {
+        //Contract should have format: "Contract/policyId/expireDate
+        return contract.split("/");
+    }
+
+    private InsurancePolicyStatus getPolicyStatus(InsurancePolicy policy) {
+        Date policyExpireDate = policy.getExpiryDate();
+        return isPolicyActive(policyExpireDate) ? InsurancePolicyStatus.ACTIVE : InsurancePolicyStatus.EXPIRED;
+    }
+
+    private boolean isPolicyActive(Date policyExpireDate) {
+        Date today = Calendar.getInstance().getTime();
+        return policyExpireDate.after(today);
+    }
 }

--- a/api/src/main/resources/components/fhirComponents.xml
+++ b/api/src/main/resources/components/fhirComponents.xml
@@ -28,6 +28,10 @@
 
     <bean id="insuranceclaims.FHIRClaimResponseService"
           class="org.openmrs.module.insuranceclaims.api.service.fhir.impl.FHIRClaimResponseServiceImpl">
-    <property name="itemService" ref="insuranceclaims.FHIRClaimItemService"/>
+        <property name="itemService" ref="insuranceclaims.FHIRClaimItemService"/>
     </bean>
+
+    <bean id="insuranceclaims.FHIREligibilityService"
+          class="org.openmrs.module.insuranceclaims.api.service.fhir.impl.FHIREligibilityServiceImpl" />
+
 </beans>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -342,6 +342,7 @@
             </column>
             <column name="start_date" type="DATETIME"/>
             <column name="expiry_date" type="DATETIME"/>
+            <column name="policy_number" type="varchar(255)"/>
             <column name="patient" type="int">
                 <constraints nullable="false"/>
             </column>

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/dao/impl/InsurancePolicyDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/dao/impl/InsurancePolicyDaoImplTest.java
@@ -36,6 +36,7 @@ public class InsurancePolicyDaoImplTest extends BaseModuleContextSensitiveTest {
 		Assert.assertThat(savedPolicy, hasProperty("expiryDate", is(policy.getExpiryDate())));
 		Assert.assertThat(savedPolicy, hasProperty("patient", is(policy.getPatient())));
 		Assert.assertThat(savedPolicy, hasProperty("status", is(policy.getStatus())));
+		Assert.assertThat(savedPolicy, hasProperty("policyNumber", is(policy.getPolicyNumber())));
 	}
 
 	private InsurancePolicy createTestInstance() {

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/mother/InsurancePolicyMother.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/mother/InsurancePolicyMother.java
@@ -4,6 +4,7 @@ import org.openmrs.Location;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.module.insuranceclaims.api.model.InsurancePolicy;
 import org.openmrs.module.insuranceclaims.api.model.InsurancePolicyStatus;
+import org.openmrs.module.insuranceclaims.api.util.TestConstants;
 
 import java.util.Date;
 
@@ -22,6 +23,7 @@ public final class InsurancePolicyMother {
 		policy.setExpiryDate(new Date());
 		policy.setPatient(PatientMother.createTestInstance(location, identifierType));
 		policy.setStatus(InsurancePolicyStatus.ACTIVE);
+		policy.setPolicyNumber(TestConstants.TEST_PATIENT_POLICY_NUMBER);
 		return policy;
 	}
 

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/fhir/FHIREligibilityServiceImpl.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/fhir/FHIREligibilityServiceImpl.java
@@ -1,0 +1,87 @@
+package org.openmrs.module.insuranceclaims.api.service.fhir;
+
+import org.hamcrest.Matchers;
+import org.hl7.fhir.dstu3.model.EligibilityRequest;
+import org.hl7.fhir.dstu3.model.EligibilityResponse;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.Location;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.fhir.api.util.FHIRConstants;
+import org.openmrs.module.insuranceclaims.api.model.InsurancePolicy;
+import org.openmrs.module.insuranceclaims.api.mother.InsurancePolicyMother;
+import org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants;
+import org.openmrs.module.insuranceclaims.api.util.TestConstants;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.openmrs.module.insuranceclaims.api.util.TestConstants.TEST_PATIENT_POLICY_NUMBER;
+
+public class FHIREligibilityServiceImpl extends BaseModuleContextSensitiveTest {
+
+    @Autowired
+    private FHIREligibilityService fhirEligibilityService;
+
+    @Test
+    public void generateEligibilityRequest_shouldMapPatientToEligibilityRequest() {
+        EligibilityRequest test = fhirEligibilityService.generateEligibilityRequest(TEST_PATIENT_POLICY_NUMBER);
+
+        Reference generatedPatientReference = test.getPatient();
+        Reference expectedReference = getExpectedReference();
+
+        Assert.assertThat(generatedPatientReference, Matchers.samePropertyValuesAs(expectedReference));
+    }
+
+    @Test
+    public void generateEligibilityRequest_shouldMapEligibilityResponseToPolicy() {
+        EligibilityResponse test = createTestEligibilityResponse();
+
+        InsurancePolicy expected = createTestPolicyInstance();
+        InsurancePolicy actual = fhirEligibilityService.generateInsurancePolicy(test);
+
+        Assert.assertThat(actual.getExpiryDate(), Matchers.equalTo(expected.getExpiryDate()));
+        Assert.assertThat(actual.getPolicyNumber(), Matchers.equalTo(expected.getPolicyNumber()));
+    }
+
+    @Test
+    public void getPolicyIdFromContractReference_shouldReturnProperId() {
+        EligibilityResponse test = createTestEligibilityResponse();
+
+        String actual = fhirEligibilityService.getPolicyIdFromContractReference(
+                test.getInsuranceFirstRep().getContract()
+        );
+
+        Assert.assertThat(TEST_PATIENT_POLICY_NUMBER, Matchers.equalTo(actual));
+    }
+
+    private InsurancePolicy createTestPolicyInstance() {
+        Location location = Context.getLocationService().getLocation(TestConstants.TEST_LOCATION_ID);
+        PatientIdentifierType identifierType = Context.getPatientService()
+                .getPatientIdentifierType(TestConstants.TEST_IDENTIFIER_TYPE_ID);
+        return InsurancePolicyMother.createTestInstance(location, identifierType);
+    }
+
+    private EligibilityResponse createTestEligibilityResponse() {
+        EligibilityResponse response = new EligibilityResponse();
+        EligibilityResponse.InsuranceComponent insuranceComponent = new EligibilityResponse.InsuranceComponent();
+        insuranceComponent.setContract(createTestContract());
+
+        return response;
+    }
+
+    private Reference createTestContract() {
+        String referenceString =  InsuranceClaimConstants.CONTRACT+ "/"
+                + TEST_PATIENT_POLICY_NUMBER + "/"
+                + TestConstants.TEST_DATE;
+
+        return new Reference(referenceString);
+    }
+    private Reference getExpectedReference() {
+        Reference expected = new Reference();
+
+        expected.setReference(FHIRConstants.PATIENT + "/" + TEST_PATIENT_POLICY_NUMBER);
+        return expected;
+    }
+}

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/utils/IdentifierUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/utils/IdentifierUtilTest.java
@@ -1,0 +1,135 @@
+package org.openmrs.module.insuranceclaims.api.service.utils;
+
+import org.hamcrest.Matchers;
+import org.hl7.fhir.dstu3.model.Claim;
+import org.hl7.fhir.dstu3.model.ClaimResponse;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.Identifier;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.api.IdentifierNotUniqueException;
+import org.openmrs.module.insuranceclaims.api.service.fhir.util.IdentifierUtil;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class IdentifierUtilTest extends BaseModuleContextSensitiveTest {
+
+    private static final String TEST_CODE = "TEST_CODE";
+
+    private static final String TEST_SYSTEM = "TEST_SYSTEM";
+
+    private static final String TEST_IDENTIFIER_VALUE = "1D3NtIFI3R";
+
+    private static final String REFERENCE_PREFIX = "isIt";
+
+    private static final String REFERENCE_SUFFIX = "Reference";
+
+    @Test
+    public void getClaimIdentifierValueBySystemCode_shouldReturnIdentifierValue() {
+        Claim testClaim = createTestClaim();
+        String actualIdentifierValue= IdentifierUtil.getClaimIdentifierValueBySystemCode(testClaim, TEST_CODE);
+
+        Assert.assertThat(actualIdentifierValue, Matchers.equalTo(TEST_IDENTIFIER_VALUE));
+    }
+
+    @Test
+    public void getClaimResponseIdentifierValueBySystemCode_shouldReturnIdentifierValue() {
+        ClaimResponse testClaim = createTestClaimResponse();
+        String actualIdentifierValue= IdentifierUtil.getClaimIdentifierValueBySystemCode(testClaim, TEST_CODE);
+
+        Assert.assertThat(actualIdentifierValue, Matchers.equalTo(TEST_IDENTIFIER_VALUE));
+    }
+
+    @Test
+    public void createIdentifer_shouldCreateCorrectIdentifer() {
+        Identifier actualIdentifier= IdentifierUtil.createIdentifier(TEST_IDENTIFIER_VALUE, TEST_CODE, TEST_SYSTEM);
+        Identifier expectedIdentifier = createTestIdentifier(TEST_CODE, TEST_SYSTEM, TEST_IDENTIFIER_VALUE);
+
+        Assert.assertThat(actualIdentifier.getValue(), Matchers.equalTo(expectedIdentifier.getValue()));
+    }
+
+    @Test
+    public void buildReference_shouldCreateCorrectReference() {
+        String expectedReferenceString = REFERENCE_PREFIX + "/" + REFERENCE_SUFFIX;
+        Reference actualReference = IdentifierUtil.buildReference(REFERENCE_PREFIX, REFERENCE_SUFFIX);
+        Assert.assertThat(actualReference.getReference(), Matchers.equalTo(expectedReferenceString));
+    }
+
+    @Test
+    public void getItFromReference_shouldReturnReferenceId() {
+        Reference testReferecne = createTestReference();
+
+        String expectedId = REFERENCE_SUFFIX;
+        String actualId = IdentifierUtil.getIdFromReference(testReferecne);
+
+        Assert.assertThat(expectedId, Matchers.equalTo(actualId));
+    }
+
+    @Test
+    public void getUnambigiousElement_shouldReturnDistinctStringFromList() {
+        List<String> testStringList = Collections.singletonList(TEST_IDENTIFIER_VALUE);
+
+        String result = IdentifierUtil.getUnambiguousElement(testStringList);
+
+        Assert.assertThat(result,Matchers.notNullValue());
+        Assert.assertThat(result,Matchers.equalTo(TEST_IDENTIFIER_VALUE));
+    }
+
+    @Test
+    public void getUnambigiousElement_shouldReturnDistinctIdentifierFromListWithTwoSameIdentifer() {
+        Identifier testIdentifier = IdentifierUtil.createIdentifier(TEST_IDENTIFIER_VALUE, TEST_CODE, TEST_SYSTEM);
+        List<Identifier> testList = Arrays.asList(testIdentifier, testIdentifier);
+
+        Identifier result = IdentifierUtil.getUnambiguousElement(testList);
+
+        Assert.assertThat(result,Matchers.notNullValue());
+        Assert.assertThat(result.getValue(),Matchers.equalTo(testIdentifier.getValue()));
+    }
+
+    @Test(expected = IdentifierNotUniqueException.class)
+    public void getUnambigiousElement_shouldThrowExceptionInUnambigiousList() {
+        String distinctString1 = "diff";
+        String distinctString2 = "strings";
+
+        List<String> testList = Arrays.asList(distinctString1, distinctString2);
+
+        IdentifierUtil.getUnambiguousElement(testList);
+    }
+
+    private Claim createTestClaim() {
+        Claim claim = new Claim();
+        claim.setIdentifier(
+                Collections.singletonList(createTestIdentifier(TEST_CODE, TEST_SYSTEM, TEST_IDENTIFIER_VALUE)));
+        return claim;
+    }
+
+    private ClaimResponse createTestClaimResponse() {
+        ClaimResponse claimResponse = new ClaimResponse();
+        claimResponse.setIdentifier(
+                Collections.singletonList(createTestIdentifier(TEST_CODE, TEST_SYSTEM, TEST_IDENTIFIER_VALUE)));
+        return claimResponse;
+    }
+
+    private Identifier createTestIdentifier(String code, String system, String value) {
+        Identifier identifier = new Identifier();
+        identifier.setValue(value);
+        identifier.setSystem(system);
+        CodeableConcept codeableConcept = new CodeableConcept();
+        Coding coding = new Coding();
+        coding.setCode(code);
+        codeableConcept.setCoding(Collections.singletonList(coding));
+        identifier.setType(codeableConcept);
+        return identifier;
+    }
+
+    private Reference createTestReference() {
+        Reference ref = new Reference();
+        ref.setReference(REFERENCE_PREFIX + "/" + REFERENCE_SUFFIX);
+        return ref;
+    }
+}

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/util/TestConstants.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/util/TestConstants.java
@@ -22,6 +22,10 @@ public final class TestConstants {
 
 	public static final String TEST_SERVICE_CODE = "M9";
 
+	public static final String TEST_PATIENT_POLICY_NUMBER = "1234567890";
+
+	public static final String TEST_DATE = "2010-10-10";
+
 	public static final double[] TEST_ENTERED_PRICES = {30, 150, 0, 20, 500, 100};
 
 	public static final double[] TEST_PROCESSED_PRICES = {100, 500, 50, 0};

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/util/TestConstants.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/util/TestConstants.java
@@ -24,11 +24,13 @@ public final class TestConstants {
 
 	public static final String TEST_PATIENT_POLICY_NUMBER = "1234567890";
 
-	public static final String TEST_DATE = "2010-10-10";
+	public static final String TEST_DATE = "2010-10-10 00:00:00";
 
 	public static final double[] TEST_ENTERED_PRICES = {30, 150, 0, 20, 500, 100};
 
 	public static final double[] TEST_PROCESSED_PRICES = {100, 500, 50, 0};
+
+	public static final String TEST_URL = "http://example.com/that";
 
 	private TestConstants() {
 	}


### PR DESCRIPTION
#### SUMMARY ####
This ticket adds mapping for Eligibility Request and Eligibility Response.
Eligibility Request is used to receive information if patient has valid policy.
Information received from EligibilityResponse are used to create InsurancePolicy connected to patient.

Ticket: [ICLM-26](https://issues.openmrs.org/browse/ICLM-26)