### PR TITLE
ICLM-28: Aded REST Client for external services communication

### DIFF
--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/ClaimHttpRequest.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/ClaimHttpRequest.java
@@ -1,0 +1,20 @@
+package org.openmrs.module.insuranceclaims.api.client;
+
+import org.hl7.fhir.dstu3.model.ClaimResponse;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.openmrs.module.insuranceclaims.api.client.impl.ClaimRequestWrapper;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+public interface ClaimHttpRequest {
+
+    ClaimResponse sendClaimRequest(String resourceUrl, InsuranceClaim insuranceClaim) throws URISyntaxException, FHIRException;
+
+    ClaimRequestWrapper getClaimRequest(String resourceUrl, String claimCode) throws URISyntaxException;
+
+    ClaimResponse getClaimResponse(String baseUrl, String claimCode) throws URISyntaxException;
+
+    List<String> getErrors();
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/ClientConstants.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/ClientConstants.java
@@ -1,0 +1,11 @@
+package org.openmrs.module.insuranceclaims.api.client;
+
+public final class ClientConstants {
+
+    public static final String API_LOGIN_PROPERTY = "insuranceclaims.externalApiLogin";
+    public static final String API_PASSWORD_PROPERTY = "insuranceclaims.externalApiPassword";
+    public static final String USER_AGENT = "user-agent";
+    public static final String CLIENT_HELPER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.99 Safari/537.36";
+
+    private ClientConstants() {};
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/ClientConstants.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/ClientConstants.java
@@ -5,6 +5,7 @@ public final class ClientConstants {
     public static final String API_LOGIN_PROPERTY = "insuranceclaims.externalApiLogin";
     public static final String API_PASSWORD_PROPERTY = "insuranceclaims.externalApiPassword";
     public static final String USER_AGENT = "user-agent";
+    //When user agent header is not present, rest template throws 403 exception
     public static final String CLIENT_HELPER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.99 Safari/537.36";
 
     private ClientConstants() {};

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/EligibilityHttpRequest.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/EligibilityHttpRequest.java
@@ -1,0 +1,11 @@
+package org.openmrs.module.insuranceclaims.api.client;
+
+import org.hl7.fhir.dstu3.model.EligibilityRequest;
+import org.hl7.fhir.dstu3.model.EligibilityResponse;
+
+import java.net.URISyntaxException;
+
+public interface EligibilityHttpRequest {
+
+    EligibilityResponse sendEligibilityRequest(String resourceUrl, EligibilityRequest request) throws URISyntaxException;
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/FHIRClient.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/FHIRClient.java
@@ -1,0 +1,13 @@
+package org.openmrs.module.insuranceclaims.api.client;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.web.client.HttpServerErrorException;
+
+import java.net.URISyntaxException;
+
+public interface FHIRClient {
+    <T,K extends IBaseResource> K postObject(String url, T object, Class<K> typeOfReturnedObject) throws URISyntaxException,
+            HttpServerErrorException;
+
+    <T extends IBaseResource> T getObject(String url, Class<T> objectClass) throws URISyntaxException;
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/FhirMessageConventer.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/FhirMessageConventer.java
@@ -2,6 +2,7 @@ package org.openmrs.module.insuranceclaims.api.client;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+import com.mchange.v1.io.InputStreamUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
@@ -10,13 +11,8 @@ import org.springframework.http.converter.AbstractHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -28,7 +24,6 @@ public class FhirMessageConventer extends AbstractHttpMessageConverter<IBaseReso
     private static final String CHARSET = "UTF-8";
     private static final String TYPE = "application";
     private static final String SUBTYPE_1 = "json";
-    private static final int BUFFER_SIZE = 1024;
 
     private IParser parser = FhirContext.forDstu3().newJsonParser();
 
@@ -66,25 +61,6 @@ public class FhirMessageConventer extends AbstractHttpMessageConverter<IBaseReso
     }
 
     private String convertStreamToString(InputStream is) throws IOException {
-        if (is != null) {
-            Writer writer = new StringWriter();
-
-            char[] buffer = new char[BUFFER_SIZE];
-            try {
-                Reader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
-                int n;
-                while ((n = reader.read(buffer)) != -1) {
-                    writer.write(buffer, 0, n);
-                }
-
-                reader.close();
-            }
-            finally {
-                is.close();
-            }
-            return writer.toString();
-        } else {
-            return "";
-        }
+        return InputStreamUtils.getContentsAsString(is);
     }
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/FhirMessageConventer.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/FhirMessageConventer.java
@@ -1,0 +1,90 @@
+package org.openmrs.module.insuranceclaims.api.client;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Generic message conventer that use application/json type and allows all FHIR Models as response type
+ */
+public class FhirMessageConventer extends AbstractHttpMessageConverter<IBaseResource> {
+
+    private static final String CHARSET = "UTF-8";
+    private static final String TYPE = "application";
+    private static final String SUBTYPE_1 = "json";
+    private static final int BUFFER_SIZE = 1024;
+
+    private IParser parser = FhirContext.forDstu3().newJsonParser();
+
+    public FhirMessageConventer() {
+        super(new MediaType(TYPE, SUBTYPE_1, Charset.forName(CHARSET)));
+    }
+
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        return IBaseResource.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    protected IBaseResource readInternal(Class<? extends IBaseResource> clazz, HttpInputMessage inputMessage)
+            throws HttpMessageNotReadableException {
+        try {
+            String json = convertStreamToString(inputMessage.getBody());
+            return parser.parseResource(json);
+        }
+        catch (IOException e) {
+            throw new HttpMessageNotReadableException("Could not read JSON: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    protected void writeInternal(IBaseResource resource, HttpOutputMessage outputMessage)
+            throws HttpMessageNotWritableException {
+        try {
+            String json = parser.encodeResourceToString(resource);
+            outputMessage.getBody().write(json.getBytes(StandardCharsets.UTF_8));
+        }
+        catch (IOException e) {
+            throw new HttpMessageNotWritableException("Could not serialize object. Msg: " + e.getMessage(), e);
+        }
+    }
+
+    private String convertStreamToString(InputStream is) throws IOException {
+        if (is != null) {
+            Writer writer = new StringWriter();
+
+            char[] buffer = new char[BUFFER_SIZE];
+            try {
+                Reader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+                int n;
+                while ((n = reader.read(buffer)) != -1) {
+                    writer.write(buffer, 0, n);
+                }
+
+                reader.close();
+            }
+            finally {
+                is.close();
+            }
+            return writer.toString();
+        } else {
+            return "";
+        }
+    }
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimHttpRequestImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimHttpRequestImpl.java
@@ -1,0 +1,90 @@
+package org.openmrs.module.insuranceclaims.api.client.impl;
+
+import org.hl7.fhir.dstu3.model.Claim;
+import org.hl7.fhir.dstu3.model.ClaimResponse;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.openmrs.module.insuranceclaims.api.client.ClaimHttpRequest;
+import org.openmrs.module.insuranceclaims.api.client.FHIRClient;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimDiagnosis;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimDiagnosisService;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimItemService;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRInsuranceClaimService;
+import org.springframework.web.client.HttpServerErrorException;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+public class ClaimHttpRequestImpl implements ClaimHttpRequest {
+
+    private FHIRClient fhirRequestClient;
+
+    private FHIRInsuranceClaimService fhirInsuranceClaimService;
+
+    private FHIRClaimDiagnosisService fhirClaimDiagnosisService;
+
+    private FHIRClaimItemService fhirClaimItemService;
+
+
+    private List<String> errors;
+
+    public void setFhirInsuranceClaimService(FHIRInsuranceClaimService fhirInsuranceClaimService) {
+        this.fhirInsuranceClaimService = fhirInsuranceClaimService;
+    }
+
+    public void setFhirClaimDiagnosisService(FHIRClaimDiagnosisService fhirClaimDiagnosisService) {
+        this.fhirClaimDiagnosisService = fhirClaimDiagnosisService;
+    }
+
+    public void setFhirClaimItemService(FHIRClaimItemService fhirClaimItemService) {
+        this.fhirClaimItemService = fhirClaimItemService;
+    }
+
+    public void setFhirRequestClient(FHIRClient fhirRequestClient) {
+        this.fhirRequestClient = fhirRequestClient;
+    }
+
+    @Override
+    public ClaimRequestWrapper getClaimRequest(String resourceUrl, String claimCode)
+            throws URISyntaxException {
+        String url = resourceUrl + "/" + claimCode;
+        Claim receivedClaim = fhirRequestClient.getObject(url, Claim.class);
+        return wrapResponse(receivedClaim);
+    }
+
+    @Override
+    public ClaimResponse sendClaimRequest(String resourceUrl, InsuranceClaim insuranceClaim)
+            throws URISyntaxException, HttpServerErrorException, FHIRException {
+        String url = resourceUrl + "/";
+        Claim claimToSend = fhirInsuranceClaimService.generateClaim(insuranceClaim);
+        return fhirRequestClient.postObject(url, claimToSend, ClaimResponse.class);
+    }
+
+    @Override
+    public ClaimResponse getClaimResponse(String baseUrl, String claimCode) throws URISyntaxException {
+        String url = baseUrl + "/" + claimCode;
+        return fhirRequestClient.getObject(url, ClaimResponse.class);
+    }
+
+    @Override
+    public List<String> getErrors() {
+        return errors != null ? errors : Collections.emptyList();
+    }
+
+    private ClaimRequestWrapper wrapResponse(Claim claim) {
+        this.errors = new ArrayList<>();
+
+        InsuranceClaim receivedClaim = fhirInsuranceClaimService.generateOmrsClaim(claim, errors);
+        List<InsuranceClaimDiagnosis> receivedDiagnosis = claim.getDiagnosis().stream()
+                .map(diagnosis -> fhirClaimDiagnosisService.createOmrsClaimDiagnosis(diagnosis, errors))
+                .collect(Collectors.toList());
+        List<InsuranceClaimItem> items = fhirClaimItemService.generateOmrsClaimItems(claim, errors);
+
+        return new ClaimRequestWrapper(receivedClaim, receivedDiagnosis, items);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimRequestWrapper.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimRequestWrapper.java
@@ -1,0 +1,53 @@
+package org.openmrs.module.insuranceclaims.api.client.impl;
+
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimDiagnosis;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
+
+import java.util.List;
+
+public class ClaimRequestWrapper {
+
+    private InsuranceClaim insuranceClaim;
+    private List<InsuranceClaimDiagnosis> diagnosis;
+    private List<InsuranceClaimItem> items;
+
+    public ClaimRequestWrapper(InsuranceClaim claim, List<InsuranceClaimDiagnosis> diagnosis,
+    List<InsuranceClaimItem> items) {
+        this.insuranceClaim = claim;
+        this.diagnosis = diagnosis;
+        this.items = items;
+    }
+
+    public InsuranceClaim getInsuranceClaim() {
+        return insuranceClaim;
+    }
+
+    public void setInsuranceClaim(InsuranceClaim insuranceClaim) {
+        this.insuranceClaim = insuranceClaim;
+    }
+
+    public List<InsuranceClaimDiagnosis> getDiagnosis() {
+        return diagnosis;
+    }
+
+    public void setDiagnosis(List<InsuranceClaimDiagnosis> diagnosis) {
+        this.diagnosis = diagnosis;
+    }
+
+    public void addDiagnosis(InsuranceClaimDiagnosis diagnosis) {
+        this.diagnosis.add(diagnosis);
+    }
+
+    public List<InsuranceClaimItem> getItems() {
+        return items;
+    }
+
+    public void setItems(List<InsuranceClaimItem> items) {
+        this.items = items;
+    }
+
+    public void addItem(InsuranceClaimItem item) {
+        this.items.add(item);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/EligibilityHttpRequestImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/EligibilityHttpRequestImpl.java
@@ -1,0 +1,25 @@
+package org.openmrs.module.insuranceclaims.api.client.impl;
+
+import org.hl7.fhir.dstu3.model.EligibilityRequest;
+import org.hl7.fhir.dstu3.model.EligibilityResponse;
+import org.openmrs.module.insuranceclaims.api.client.EligibilityHttpRequest;
+
+import java.net.URISyntaxException;
+
+public class EligibilityHttpRequestImpl implements EligibilityHttpRequest {
+
+    private FhirRequestClient client;
+
+    public EligibilityHttpRequestImpl() {
+        client = new FhirRequestClient();
+    }
+
+    @Override
+    public EligibilityResponse sendEligibilityRequest(String resourceUrl, EligibilityRequest request)
+            throws URISyntaxException {
+        String url = resourceUrl + "/";
+        EligibilityResponse response = client.postObject(url, request, EligibilityResponse.class);
+
+        return response;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/FhirRequestClient.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/FhirRequestClient.java
@@ -73,8 +73,7 @@ public class FhirRequestClient implements FHIRClient {
         headers.setContentType(MediaType.APPLICATION_JSON);
     }
 
-    private <L>ClientHttpEntity createPostClientHttpEntity(String url, L object)
-    throws URISyntaxException {
+    private <L> ClientHttpEntity createPostClientHttpEntity(String url, L object) throws URISyntaxException {
         ClientHttpEntity clientHttpEntity = fhirClientHelper.createRequest(url, object);
         clientHttpEntity.setMethod(HttpMethod.POST);
         clientHttpEntity.setUrl(new URI(url));

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/FhirRequestClient.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/FhirRequestClient.java
@@ -1,0 +1,89 @@
+package org.openmrs.module.insuranceclaims.api.client.impl;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.fhir.api.client.ClientHttpEntity;
+import org.openmrs.module.fhir.api.client.ClientHttpRequestInterceptor;
+import org.openmrs.module.fhir.api.helper.ClientHelper;
+import org.openmrs.module.fhir.api.helper.FHIRClientHelper;
+import org.openmrs.module.insuranceclaims.api.client.FHIRClient;
+import org.openmrs.module.insuranceclaims.api.client.FhirMessageConventer;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openmrs.module.insuranceclaims.api.client.ClientConstants.API_LOGIN_PROPERTY;
+import static org.openmrs.module.insuranceclaims.api.client.ClientConstants.API_PASSWORD_PROPERTY;
+import static org.openmrs.module.insuranceclaims.api.client.ClientConstants.CLIENT_HELPER_USER_AGENT;
+import static org.openmrs.module.insuranceclaims.api.client.ClientConstants.USER_AGENT;
+
+public class FhirRequestClient implements FHIRClient {
+
+    private RestTemplate restTemplate = new RestTemplate();
+
+    private ClientHelper fhirClientHelper = new FHIRClientHelper();
+
+    private HttpHeaders headers = new HttpHeaders();
+
+    private AbstractHttpMessageConverter<IBaseResource> conventer = new FhirMessageConventer();
+
+    public <T extends IBaseResource> T getObject(String url, Class<T> objectClass) throws URISyntaxException {
+        prepareRestTemplate();
+        setRequestHeaders();
+        ClientHttpEntity clientHttpEntity = fhirClientHelper.retrieveRequest(url);
+        ResponseEntity<T> response = sendRequest(clientHttpEntity, objectClass);
+        return response.getBody();
+    }
+
+    public <T,K extends IBaseResource> K postObject(String url, T object, Class<K> objectClass) throws URISyntaxException,
+            HttpServerErrorException {
+        prepareRestTemplate();
+        setRequestHeaders();
+        ClientHttpEntity clientHttpEntity = createPostClientHttpEntity(url, object);
+        ResponseEntity<K> response = sendRequest(clientHttpEntity, objectClass);
+        return response.getBody();
+    }
+
+    private <L> ResponseEntity<L> sendRequest(ClientHttpEntity clientHttpEntity, Class<L> objectClass)  {
+        HttpEntity entity = new HttpEntity(clientHttpEntity.getBody(), headers);
+        return restTemplate.exchange(clientHttpEntity.getUrl(), clientHttpEntity.getMethod(), entity, objectClass);
+    }
+
+    private void setRequestHeaders() {
+        headers = new HttpHeaders();
+        String username = Context.getAdministrationService().getGlobalProperty(API_LOGIN_PROPERTY);
+        String password = Context.getAdministrationService().getGlobalProperty(API_PASSWORD_PROPERTY);
+
+        for (ClientHttpRequestInterceptor interceptor : fhirClientHelper.getCustomInterceptors(username, password)) {
+            interceptor.addToHeaders(headers);
+        }
+
+        headers.add(USER_AGENT, CLIENT_HELPER_USER_AGENT);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+    }
+
+    private <L>ClientHttpEntity createPostClientHttpEntity(String url, L object)
+    throws URISyntaxException {
+        ClientHttpEntity clientHttpEntity = fhirClientHelper.createRequest(url, object);
+        clientHttpEntity.setMethod(HttpMethod.POST);
+        clientHttpEntity.setUrl(new URI(url));
+        return clientHttpEntity;
+    }
+
+    private void prepareRestTemplate() {
+        List<HttpMessageConverter<?>> converters = new ArrayList<>(fhirClientHelper.getCustomMessageConverter());
+        converters.add(conventer);
+        restTemplate.setMessageConverters(converters);
+    }
+}

--- a/api/src/main/resources/components/clientComponents.xml
+++ b/api/src/main/resources/components/clientComponents.xml
@@ -6,17 +6,15 @@
             http://www.springframework.org/schema/context
             http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
-    <context:component-scan base-package="org.openmrs.module.insuranceclaims"/>
-
-    <bean id="insuranceclaims.InsuranceClient"
-          class="org.openmrs.module.insuranceclaims.api.client.InsuranceClient" >
+    <bean id="insuranceclaims.FhirRequest"
+          class="org.openmrs.module.insuranceclaims.api.client.impl.FhirRequestClient" >
     </bean>
 
     <bean id="insuranceclaims.ClaimHttpRequest"
           class="org.openmrs.module.insuranceclaims.api.client.impl.ClaimHttpRequestImpl">
         <property name="fhirInsuranceClaimService" ref="insuranceclaims.FHIRInsuranceClaimService"/>
         <property name="fhirClaimDiagnosisService" ref="insuranceclaims.FHIRClaimDiagnosisService"/>
-        <property name="fhirClaimItemService" ref="insuranceclaims.FHIRClaimItemService" />
-        <property name="insuranceClient" ref="insuranceclaims.InsuranceClient" />
+        <property name="fhirClaimItemService"      ref="insuranceclaims.FHIRClaimItemService"/>
+        <property name="fhirRequestClient"         ref="insuranceclaims.FhirRequest" />
     </bean>
 </beans>

--- a/api/src/main/resources/components/fhirComponents.xml
+++ b/api/src/main/resources/components/fhirComponents.xml
@@ -6,17 +6,14 @@
             http://www.springframework.org/schema/context
             http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
-    <context:component-scan base-package="org.openmrs.module.insuranceclaims"/>
-
     <bean id="insuranceclaims.FHIRClaimDiagnosisService"
           class="org.openmrs.module.insuranceclaims.api.service.fhir.impl.FHIRClaimDiagnosisServiceImpl">
         <property name="diagnosisDbService" ref="insuranceclaims.DiagnosisDbService"/>
     </bean>
 
-
     <bean id="insuranceclaims.FHIRClaimItemService"
           class="org.openmrs.module.insuranceclaims.api.service.fhir.impl.FHIRClaimItemServiceImpl">
-    <property name="itemDbService" ref="insuranceclaims.ItemDbService"/>
+        <property name="itemDbService" ref="insuranceclaims.ItemDbService"/>
     </bean>
 
     <bean id="insuranceclaims.FHIRInsuranceClaimService"

--- a/api/src/main/resources/components/insuranceServiceComponents.xml
+++ b/api/src/main/resources/components/insuranceServiceComponents.xml
@@ -7,8 +7,6 @@
             http://www.springframework.org/schema/context
             http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
-    <context:component-scan base-package="org.openmrs.module.insuranceclaims"/>
-
     <!-- Wraps InsuranceClaimService methods in DB transactions and OpenMRS interceptors,
          which set audit info like dateCreated, changedBy, etc.-->
 

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -20,15 +20,9 @@
     <import resource="classpath:components/fhirComponents.xml" />
     <import resource="classpath:components/clientComponents.xml" />
 
-<!--    <bean id="insuranceclaims.ClaimHttpRequest"-->
-<!--          class="org.openmrs.module.insuranceclaims.api.client.impl.ClaimHttpRequestImpl">-->
-<!--        <property name="fhirInsuranceClaimService" ref="insuranceclaims.FHIRInsuranceClaimService"/>-->
-<!--        <property name="fhirClaimDiagnosisService" ref="insuranceclaims.FHIRClaimDiagnosisService"/>-->
-<!--        <property name="fhirRequestClient" value="org.openmrs.module.insuranceclaims.api.client.impl.FhirRequestClient" />-->
-<!--    </bean>-->
-
     <!-- Adds module services to OpenMRS context so it can be accessed
     calling e.g. Context.getService(InsuranceClaimService.class) -->
+
     <bean parent="serviceContext">
         <property name="moduleService">
             <list>
@@ -61,6 +55,15 @@
             <list>
                 <value>org.openmrs.module.insuranceclaims.api.service.InsuranceClaimDiagnosisService</value>
                 <ref bean="insuranceclaims.InsuranceClaimDiagnosisService"/>
+            </list>
+        </property>
+    </bean>
+
+    <bean parent="serviceContext">
+        <property name="moduleService">
+            <list>
+                <value>org.openmrs.module.insuranceclaims.api.service.ProvidedItemService</value>
+                <ref bean="insuranceclaims.ProvidedItemService"/>
             </list>
         </property>
     </bean>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -15,11 +15,17 @@
     <bean id="insuranceclaims.DateUtil" class="org.openmrs.module.insuranceclaims.util.DateUtil" />
 
     <import resource="classpath:components/daoComponents.xml" />
-
-
     <import resource="classpath:components/insuranceServiceComponents.xml" />
     <import resource="classpath:components/dbComponents.xml" />
     <import resource="classpath:components/fhirComponents.xml" />
+    <import resource="classpath:components/clientComponents.xml" />
+
+<!--    <bean id="insuranceclaims.ClaimHttpRequest"-->
+<!--          class="org.openmrs.module.insuranceclaims.api.client.impl.ClaimHttpRequestImpl">-->
+<!--        <property name="fhirInsuranceClaimService" ref="insuranceclaims.FHIRInsuranceClaimService"/>-->
+<!--        <property name="fhirClaimDiagnosisService" ref="insuranceclaims.FHIRClaimDiagnosisService"/>-->
+<!--        <property name="fhirRequestClient" value="org.openmrs.module.insuranceclaims.api.client.impl.FhirRequestClient" />-->
+<!--    </bean>-->
 
     <!-- Adds module services to OpenMRS context so it can be accessed
     calling e.g. Context.getService(InsuranceClaimService.class) -->

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimHttpRequestImplTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimHttpRequestImplTest.java
@@ -1,145 +1,62 @@
 package org.openmrs.module.insuranceclaims.api.client.impl;
 
 import org.hamcrest.Matchers;
+import org.hl7.fhir.dstu3.model.Claim;
 import org.hl7.fhir.dstu3.model.ClaimResponse;
-import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.exceptions.FHIRException;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.openmrs.Location;
-import org.openmrs.PatientIdentifierType;
-import org.openmrs.Provider;
-import org.openmrs.VisitType;
-import org.openmrs.api.context.Context;
-import org.openmrs.module.insuranceclaims.api.client.ClaimHttpRequest;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
-import org.openmrs.module.insuranceclaims.api.mother.InsuranceClaimMother;
-import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimService;
-import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimResponseService;
 import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRInsuranceClaimService;
-import org.openmrs.module.insuranceclaims.api.util.TestConstants;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.net.URISyntaxException;
 
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
-import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.PATIENT_EXTERNAL_ID_IDENTIFIER_UUID;
-import static org.openmrs.module.insuranceclaims.api.util.TestConstants.EXTERNAL_ID_DATASET_PATH;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ClaimHttpRequestImplTest extends BaseModuleContextSensitiveTest {
-    static String BASE_URL = "http://localhost:8000/api_fhir";
-    static String CLAIM_RESPONSE_URL = BASE_URL + "/" + "ClaimResponse";
-    static String CLAIM_URL = BASE_URL + "/" + "Claim";
-    static String TEST_CODE = "clCode";
+    private static String BASE_URL = "http://localhost:8000/api_fhir";
+    private static String CLAIM_RESPONSE_URL = BASE_URL + "/" + "ClaimResponse";
+    private static String CLAIM_URL = BASE_URL + "/" + "Claim";
+    private static String TEST_CODE = "clCode";
 
     @Mock
     private FhirRequestClient client;
 
+    @Mock
+    private FHIRInsuranceClaimService fhirInsuranceClaimService;
+
     @InjectMocks
-    @Autowired
     private ClaimHttpRequestImpl request;
-
-    @Autowired
-    private ClaimHttpRequest autowiredRequest;
-
-    @Autowired
-    private InsuranceClaimService insuranceClaimService;
-
-    @Autowired
-    private FHIRClaimResponseService claimResponseService;
-
-    @Autowired
-    private FHIRInsuranceClaimService fhirClaimService;
-
-    private InsuranceClaim testInsuranceClaim;
-
-    @Before
-    public void setUpClass() throws Exception {
-        executeDataSet(EXTERNAL_ID_DATASET_PATH);
-
-        testInsuranceClaim = createTestInstance();
-
-        insuranceClaimService.saveOrUpdate(testInsuranceClaim);
-    }
-
-    @Before
-    public void setup() throws Exception {
-        String identifierSource = "test_externalId_attribute_types.xml";
-        executeDataSet(identifierSource);
-    }
-
-    public <T extends IBaseResource> void setupGetRequestMock(Class<T> expectedClass, String url, Object returnValue)
-    throws URISyntaxException {
-        when(client.getObject(eq(url), eq(expectedClass))).thenReturn((T) returnValue);
-    }
-
-    public <T, K extends IBaseResource> void setupPostRequestMock(Class<T> expectedObjectToSend, K response, String url)
-    throws URISyntaxException {
-        when(client.postObject(eq(url), any(expectedObjectToSend), eq(response.getClass())))
-                .thenAnswer(i -> response);
-    }
-
-    @Test
-    public void autowiredRequest_shouldNotBeNull() {
-        Assert.assertThat(autowiredRequest, is(notNullValue()));
-    }
-
-//    @Test
-//    public void getClaimRequest_shouldRequestProperClaim() throws URISyntaxException, FHIRException {
-//        String expectedUrlCall = CLAIM_URL + "/" + TEST_CODE;
-//
-//        Claim claimToReturn = fhirClaimService.generateClaim(testInsuranceClaim);
-//        InsuranceClaim expected = fhirClaimService.generateOmrsClaim(claimToReturn, new ArrayList<>());
-//        setupGetRequestMock(ClaimResponse.class, expectedUrlCall, claimToReturn);
-//
-//        ClaimHttpRequest x = request;
-//        ClaimRequestWrapper result = x.getClaimRequest(CLAIM_URL, TEST_CODE);
-//
-//        Assert.assertThat(result.getInsuranceClaim(), Matchers.samePropertyValuesAs(expected));
-//        Assert.assertThat(result.getDiagnosis(), Matchers.hasSize(0));
-//    }
 
     @Test
     public void getClaimResponseRequest_shouldRequestProperClaim() throws URISyntaxException {
         String expectedUrlCall = CLAIM_RESPONSE_URL + "/" + TEST_CODE;
+        ClaimResponse claimToReturn = new ClaimResponse();
+        when(client.getObject(eq(expectedUrlCall), eq(ClaimResponse.class))).thenReturn(claimToReturn);
 
-        ClaimResponse claimToReturn = claimResponseService.generateClaimResponse(testInsuranceClaim);
-        setupGetRequestMock(ClaimResponse.class, expectedUrlCall, claimToReturn);
-
-        ClaimHttpRequest x = request;
-        ClaimResponse result = x.getClaimResponse(CLAIM_RESPONSE_URL, TEST_CODE);
+        ClaimResponse result = request.getClaimResponse(CLAIM_RESPONSE_URL, TEST_CODE);
 
         Assert.assertThat(result, Matchers.samePropertyValuesAs(claimToReturn));
     }
 
-//    @Test
-//    public void sendClaimRequest_shouldPassFhirObjectToClient() throws URISyntaxException, FHIRException {
-//        String expectedUrlCall = CLAIM_URL + "/";
-//        InsuranceClaim claim = testInsuranceClaim;
-//        Claim claimToSend = fhirClaimService.generateClaim(claim);
-//
-//        setupPostRequestMock(claimToSend.getClass(), claimToSend, expectedUrlCall);
-//        ClaimHttpRequest x = request;
-//        ClaimResponse result = x.sendClaimRequest(CLAIM_URL, claim);
-//        Assert.assertThat(result, Matchers.samePropertyValuesAs(claimToSend));
-//    }
+    @Test
+    public void sendClaimRequest_shouldPassFhirObjectToClient() throws URISyntaxException, FHIRException {
+        String expectedUrlCall = CLAIM_URL + "/";
+        InsuranceClaim claim = new InsuranceClaim();
+        Claim claimToSend = new Claim();
+        ClaimResponse toBeReturned = new ClaimResponse();
 
-    private InsuranceClaim createTestInstance() {
-        Location location = Context.getLocationService().getLocation(TestConstants.TEST_LOCATION_ID);
-        Provider provider = Context.getProviderService().getProvider(TestConstants.TEST_PROVIDER_ID);
-        VisitType visitType = Context.getVisitService().getVisitType(TestConstants.TEST_VISIT_TYPE_ID);
-        PatientIdentifierType identifierType = Context.getPatientService()
-                .getPatientIdentifierTypeByUuid(PATIENT_EXTERNAL_ID_IDENTIFIER_UUID);
-        return InsuranceClaimMother.createTestInstance(location, provider, visitType, identifierType);
+        when(client.postObject(eq(expectedUrlCall), eq(claimToSend), eq(toBeReturned.getClass()))).thenAnswer(i -> toBeReturned);
+        when(fhirInsuranceClaimService.generateClaim(claim)).thenReturn(claimToSend);
+        ClaimResponse result = request.sendClaimRequest(CLAIM_URL, claim);
+
+        Assert.assertThat(result, Matchers.samePropertyValuesAs(toBeReturned));
     }
 }

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimHttpRequestImplTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimHttpRequestImplTest.java
@@ -1,0 +1,145 @@
+package org.openmrs.module.insuranceclaims.api.client.impl;
+
+import org.hamcrest.Matchers;
+import org.hl7.fhir.dstu3.model.ClaimResponse;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.openmrs.Location;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.Provider;
+import org.openmrs.VisitType;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.insuranceclaims.api.client.ClaimHttpRequest;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+import org.openmrs.module.insuranceclaims.api.mother.InsuranceClaimMother;
+import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimService;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimResponseService;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRInsuranceClaimService;
+import org.openmrs.module.insuranceclaims.api.util.TestConstants;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.net.URISyntaxException;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.PATIENT_EXTERNAL_ID_IDENTIFIER_UUID;
+import static org.openmrs.module.insuranceclaims.api.util.TestConstants.EXTERNAL_ID_DATASET_PATH;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ClaimHttpRequestImplTest extends BaseModuleContextSensitiveTest {
+    static String BASE_URL = "http://localhost:8000/api_fhir";
+    static String CLAIM_RESPONSE_URL = BASE_URL + "/" + "ClaimResponse";
+    static String CLAIM_URL = BASE_URL + "/" + "Claim";
+    static String TEST_CODE = "clCode";
+
+    @Mock
+    private FhirRequestClient client;
+
+    @InjectMocks
+    @Autowired
+    private ClaimHttpRequestImpl request;
+
+    @Autowired
+    private ClaimHttpRequest autowiredRequest;
+
+    @Autowired
+    private InsuranceClaimService insuranceClaimService;
+
+    @Autowired
+    private FHIRClaimResponseService claimResponseService;
+
+    @Autowired
+    private FHIRInsuranceClaimService fhirClaimService;
+
+    private InsuranceClaim testInsuranceClaim;
+
+    @Before
+    public void setUpClass() throws Exception {
+        executeDataSet(EXTERNAL_ID_DATASET_PATH);
+
+        testInsuranceClaim = createTestInstance();
+
+        insuranceClaimService.saveOrUpdate(testInsuranceClaim);
+    }
+
+    @Before
+    public void setup() throws Exception {
+        String identifierSource = "test_externalId_attribute_types.xml";
+        executeDataSet(identifierSource);
+    }
+
+    public <T extends IBaseResource> void setupGetRequestMock(Class<T> expectedClass, String url, Object returnValue)
+    throws URISyntaxException {
+        when(client.getObject(eq(url), eq(expectedClass))).thenReturn((T) returnValue);
+    }
+
+    public <T, K extends IBaseResource> void setupPostRequestMock(Class<T> expectedObjectToSend, K response, String url)
+    throws URISyntaxException {
+        when(client.postObject(eq(url), any(expectedObjectToSend), eq(response.getClass())))
+                .thenAnswer(i -> response);
+    }
+
+    @Test
+    public void autowiredRequest_shouldNotBeNull() {
+        Assert.assertThat(autowiredRequest, is(notNullValue()));
+    }
+
+//    @Test
+//    public void getClaimRequest_shouldRequestProperClaim() throws URISyntaxException, FHIRException {
+//        String expectedUrlCall = CLAIM_URL + "/" + TEST_CODE;
+//
+//        Claim claimToReturn = fhirClaimService.generateClaim(testInsuranceClaim);
+//        InsuranceClaim expected = fhirClaimService.generateOmrsClaim(claimToReturn, new ArrayList<>());
+//        setupGetRequestMock(ClaimResponse.class, expectedUrlCall, claimToReturn);
+//
+//        ClaimHttpRequest x = request;
+//        ClaimRequestWrapper result = x.getClaimRequest(CLAIM_URL, TEST_CODE);
+//
+//        Assert.assertThat(result.getInsuranceClaim(), Matchers.samePropertyValuesAs(expected));
+//        Assert.assertThat(result.getDiagnosis(), Matchers.hasSize(0));
+//    }
+
+    @Test
+    public void getClaimResponseRequest_shouldRequestProperClaim() throws URISyntaxException {
+        String expectedUrlCall = CLAIM_RESPONSE_URL + "/" + TEST_CODE;
+
+        ClaimResponse claimToReturn = claimResponseService.generateClaimResponse(testInsuranceClaim);
+        setupGetRequestMock(ClaimResponse.class, expectedUrlCall, claimToReturn);
+
+        ClaimHttpRequest x = request;
+        ClaimResponse result = x.getClaimResponse(CLAIM_RESPONSE_URL, TEST_CODE);
+
+        Assert.assertThat(result, Matchers.samePropertyValuesAs(claimToReturn));
+    }
+
+//    @Test
+//    public void sendClaimRequest_shouldPassFhirObjectToClient() throws URISyntaxException, FHIRException {
+//        String expectedUrlCall = CLAIM_URL + "/";
+//        InsuranceClaim claim = testInsuranceClaim;
+//        Claim claimToSend = fhirClaimService.generateClaim(claim);
+//
+//        setupPostRequestMock(claimToSend.getClass(), claimToSend, expectedUrlCall);
+//        ClaimHttpRequest x = request;
+//        ClaimResponse result = x.sendClaimRequest(CLAIM_URL, claim);
+//        Assert.assertThat(result, Matchers.samePropertyValuesAs(claimToSend));
+//    }
+
+    private InsuranceClaim createTestInstance() {
+        Location location = Context.getLocationService().getLocation(TestConstants.TEST_LOCATION_ID);
+        Provider provider = Context.getProviderService().getProvider(TestConstants.TEST_PROVIDER_ID);
+        VisitType visitType = Context.getVisitService().getVisitType(TestConstants.TEST_VISIT_TYPE_ID);
+        PatientIdentifierType identifierType = Context.getPatientService()
+                .getPatientIdentifierTypeByUuid(PATIENT_EXTERNAL_ID_IDENTIFIER_UUID);
+        return InsuranceClaimMother.createTestInstance(location, provider, visitType, identifierType);
+    }
+}

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/EligibilityHttpRequestTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/EligibilityHttpRequestTest.java
@@ -42,6 +42,8 @@ public class EligibilityHttpRequestTest extends BaseModuleContextSensitiveTest {
         EligibilityResponse response = new EligibilityResponse();
 
         setupPostRequestMock(eligibilityRequest.getClass(), response, expectedUrlCall);
+        when(client.postObject(eq(expectedUrlCall), eq(eligibilityRequest), eq(response.getClass())))
+                .thenAnswer(i -> response);
         EligibilityResponse result = request.sendEligibilityRequest(BASE_URL, eligibilityRequest);
         Assert.assertThat(result, Matchers.samePropertyValuesAs(response));
     }

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/EligibilityHttpRequestTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/EligibilityHttpRequestTest.java
@@ -3,7 +3,6 @@ package org.openmrs.module.insuranceclaims.api.client.impl;
 import org.hamcrest.Matchers;
 import org.hl7.fhir.dstu3.model.EligibilityRequest;
 import org.hl7.fhir.dstu3.model.EligibilityResponse;
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,7 +13,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.net.URISyntaxException;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -29,19 +27,12 @@ public class EligibilityHttpRequestTest extends BaseModuleContextSensitiveTest {
     @Mock
     FhirRequestClient client;
 
-    public <T, K extends IBaseResource> void setupPostRequestMock(Class<T> expectedObjectToSend, K response, String url)
-            throws URISyntaxException {
-        when(client.postObject(eq(url), any(expectedObjectToSend), eq(response.getClass())))
-                .thenAnswer(i -> response);
-    }
-
     @Test
     public void sendEligibilityRequest_shouldPassFhirObjectToClient() throws URISyntaxException {
         String expectedUrlCall = BASE_URL + "/";
         EligibilityRequest eligibilityRequest = new EligibilityRequest();
         EligibilityResponse response = new EligibilityResponse();
 
-        setupPostRequestMock(eligibilityRequest.getClass(), response, expectedUrlCall);
         when(client.postObject(eq(expectedUrlCall), eq(eligibilityRequest), eq(response.getClass())))
                 .thenAnswer(i -> response);
         EligibilityResponse result = request.sendEligibilityRequest(BASE_URL, eligibilityRequest);

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/EligibilityHttpRequestTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/EligibilityHttpRequestTest.java
@@ -1,0 +1,48 @@
+package org.openmrs.module.insuranceclaims.api.client.impl;
+
+import org.hamcrest.Matchers;
+import org.hl7.fhir.dstu3.model.EligibilityRequest;
+import org.hl7.fhir.dstu3.model.EligibilityResponse;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.net.URISyntaxException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class EligibilityHttpRequestTest extends BaseModuleContextSensitiveTest {
+
+    static String BASE_URL = "http://localhost:8000/api_fhir/EligibilityResponse";
+
+    @InjectMocks
+    EligibilityHttpRequestImpl request;
+
+    @Mock
+    FhirRequestClient client;
+
+    public <T, K extends IBaseResource> void setupPostRequestMock(Class<T> expectedObjectToSend, K response, String url)
+            throws URISyntaxException {
+        when(client.postObject(eq(url), any(expectedObjectToSend), eq(response.getClass())))
+                .thenAnswer(i -> response);
+    }
+
+    @Test
+    public void sendEligibilityRequest_shouldPassFhirObjectToClient() throws URISyntaxException {
+        String expectedUrlCall = BASE_URL + "/";
+        EligibilityRequest eligibilityRequest = new EligibilityRequest();
+        EligibilityResponse response = new EligibilityResponse();
+
+        setupPostRequestMock(eligibilityRequest.getClass(), response, expectedUrlCall);
+        EligibilityResponse result = request.sendEligibilityRequest(BASE_URL, eligibilityRequest);
+        Assert.assertThat(result, Matchers.samePropertyValuesAs(response));
+    }
+}

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/InsuranceClientTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/InsuranceClientTest.java
@@ -55,17 +55,17 @@ public class InsuranceClientTest extends BaseModuleContextSensitiveTest {
         Assert.assertThat(expected, Matchers.equalTo(actual));
     }
 
-    public <T> void setupGetRequestMock(Class<T> returnedObjectClass, T objectToReturn, String url)
+    private <T> void setupGetRequestMock(Class<T> returnedObjectClass, T objectToReturn, String url)
     throws URISyntaxException {
         createRequestMock(url, HttpMethod.GET, returnedObjectClass, objectToReturn);
     }
 
-    public <T> void setupPostRequestMock(Class<T> returnedObjectClass, T objectToReturn,  String url)
+    private <T> void setupPostRequestMock(Class<T> returnedObjectClass, T objectToReturn,  String url)
     throws URISyntaxException {
         createRequestMock(url, HttpMethod.POST, returnedObjectClass, objectToReturn);
     }
 
-    public <T> void createRequestMock(String url, HttpMethod method, Class<T> requestedObjectClass, T objectToReturn)
+    private  <T> void createRequestMock(String url, HttpMethod method, Class<T> requestedObjectClass, T objectToReturn)
     throws URISyntaxException {
         given(restTemplate.exchange(
                 eq(new URI(url)),

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/InsuranceClientTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/InsuranceClientTest.java
@@ -7,10 +7,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -24,14 +25,14 @@ import static org.mockito.Matchers.eq;
 import static org.openmrs.module.insuranceclaims.api.util.TestConstants.TEST_URL;
 import static org.springframework.http.HttpStatus.ACCEPTED;
 
-@RunWith(MockitoJUnitRunner.class)
-public class InsuranceClientTest {
+@RunWith(SpringJUnit4ClassRunner.class)
+public class InsuranceClientTest extends BaseModuleContextSensitiveTest {
 
     @Mock
-    RestTemplate restTemplate;
+    private RestTemplate restTemplate;
 
     @InjectMocks
-    FhirRequestClient client = new FhirRequestClient();
+    private FhirRequestClient client = new FhirRequestClient();
 
     @Test
     public void getClient_shouldReturnNotNullService() {
@@ -40,7 +41,7 @@ public class InsuranceClientTest {
 
     @Test
     public void shouldSendGetRequestForClaimObject_shouldReturnClaim() throws URISyntaxException {
-        Claim expected = createTestClaim();
+        Claim expected = new Claim();
         setupGetRequestMock(Claim.class,  expected, TEST_URL);
         Claim actual = client.getObject(TEST_URL, Claim.class);
         Assert.assertThat(expected, Matchers.equalTo(actual));
@@ -48,14 +49,10 @@ public class InsuranceClientTest {
 
     @Test
     public void shouldSendPostRequestWithClaimObject_shouldReturnClaim() throws URISyntaxException {
-        Claim expected = createTestClaim();
+        Claim expected = new Claim();
         setupPostRequestMock(Claim.class,  expected, TEST_URL);
         Claim actual = client.postObject(TEST_URL, expected, Claim.class);
         Assert.assertThat(expected, Matchers.equalTo(actual));
-    }
-
-    private Claim createTestClaim() {
-        return new Claim();
     }
 
     public <T> void setupGetRequestMock(Class<T> returnedObjectClass, T objectToReturn, String url)

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/InsuranceClientTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/client/impl/InsuranceClientTest.java
@@ -1,0 +1,86 @@
+package org.openmrs.module.insuranceclaims.api.client.impl;
+
+import org.hamcrest.Matchers;
+import org.hl7.fhir.dstu3.model.Claim;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.openmrs.module.insuranceclaims.api.util.TestConstants.TEST_URL;
+import static org.springframework.http.HttpStatus.ACCEPTED;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InsuranceClientTest {
+
+    @Mock
+    RestTemplate restTemplate;
+
+    @InjectMocks
+    FhirRequestClient client = new FhirRequestClient();
+
+    @Test
+    public void getClient_shouldReturnNotNullService() {
+        Assert.assertThat(client, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldSendGetRequestForClaimObject_shouldReturnClaim() throws URISyntaxException {
+        Claim expected = createTestClaim();
+        setupGetRequestMock(Claim.class,  expected, TEST_URL);
+        Claim actual = client.getObject(TEST_URL, Claim.class);
+        Assert.assertThat(expected, Matchers.equalTo(actual));
+    }
+
+    @Test
+    public void shouldSendPostRequestWithClaimObject_shouldReturnClaim() throws URISyntaxException {
+        Claim expected = createTestClaim();
+        setupPostRequestMock(Claim.class,  expected, TEST_URL);
+        Claim actual = client.postObject(TEST_URL, expected, Claim.class);
+        Assert.assertThat(expected, Matchers.equalTo(actual));
+    }
+
+    private Claim createTestClaim() {
+        return new Claim();
+    }
+
+    public <T> void setupGetRequestMock(Class<T> returnedObjectClass, T objectToReturn, String url)
+    throws URISyntaxException {
+        createRequestMock(url, HttpMethod.GET, returnedObjectClass, objectToReturn);
+    }
+
+    public <T> void setupPostRequestMock(Class<T> returnedObjectClass, T objectToReturn,  String url)
+    throws URISyntaxException {
+        createRequestMock(url, HttpMethod.POST, returnedObjectClass, objectToReturn);
+    }
+
+    public <T> void createRequestMock(String url, HttpMethod method, Class<T> requestedObjectClass, T objectToReturn)
+    throws URISyntaxException {
+        given(restTemplate.exchange(
+                eq(new URI(url)),
+                eq(method),
+                any(HttpEntity.class),
+                eq(requestedObjectClass)))
+                .willReturn(mockResponseEntityBody(objectToReturn));
+    }
+
+    private <T> ResponseEntity mockResponseEntityBody(T objectToReturn) {
+        ResponseEntity responseEntity = new ResponseEntity<T>(objectToReturn, ACCEPTED);
+        return responseEntity;
+    }
+
+}


### PR DESCRIPTION
### SUMMARY 
Added rest client that allows to communicate with external systems. External server information  (e.g. URL) can be customized through global properties. 
Client allows user to send queries about: 
- Claim
- ClaimResponse 
- Eligibility