### PR TITLE
ICLM-30: Added endpoint for sending claim to external system

### DIFF
--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/ClaimHttpRequest.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/ClaimHttpRequest.java
@@ -1,20 +1,17 @@
 package org.openmrs.module.insuranceclaims.api.client;
 
+import org.hl7.fhir.dstu3.model.Claim;
 import org.hl7.fhir.dstu3.model.ClaimResponse;
 import org.hl7.fhir.exceptions.FHIRException;
-import org.openmrs.module.insuranceclaims.api.client.impl.ClaimRequestWrapper;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
 
 import java.net.URISyntaxException;
-import java.util.List;
 
 public interface ClaimHttpRequest {
 
     ClaimResponse sendClaimRequest(String resourceUrl, InsuranceClaim insuranceClaim) throws URISyntaxException, FHIRException;
 
-    ClaimRequestWrapper getClaimRequest(String resourceUrl, String claimCode) throws URISyntaxException;
+    Claim getClaimRequest(String resourceUrl, String claimCode) throws URISyntaxException;
 
     ClaimResponse getClaimResponse(String baseUrl, String claimCode) throws URISyntaxException;
-
-    List<String> getErrors();
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/ClientConstants.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/ClientConstants.java
@@ -8,5 +8,9 @@ public final class ClientConstants {
     //When user agent header is not present, rest template throws 403 exception
     public static final String CLIENT_HELPER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.99 Safari/537.36";
 
+    public static final String BASE_URL_PROPERTY = "insuranceclaims.baseInsuranceClaimUrl";
+    public static final String CLAIM_RESPONSE_SOURCE_URI = "insuranceclaims.claimResponseResource";
+    public static final String CLAIM_SOURCE_URI = "insuranceclaims.claimResource";
+
     private ClientConstants() {};
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimHttpRequestImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimHttpRequestImpl.java
@@ -6,18 +6,10 @@ import org.hl7.fhir.exceptions.FHIRException;
 import org.openmrs.module.insuranceclaims.api.client.ClaimHttpRequest;
 import org.openmrs.module.insuranceclaims.api.client.FHIRClient;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
-import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimDiagnosis;
-import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
-import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimDiagnosisService;
-import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimItemService;
 import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRInsuranceClaimService;
 import org.springframework.web.client.HttpServerErrorException;
 
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class ClaimHttpRequestImpl implements ClaimHttpRequest {
 
@@ -25,18 +17,11 @@ public class ClaimHttpRequestImpl implements ClaimHttpRequest {
 
     private FHIRInsuranceClaimService fhirInsuranceClaimService;
 
-    private FHIRClaimDiagnosisService fhirClaimDiagnosisService;
-
-    private FHIRClaimItemService fhirClaimItemService;
-
-    private List<String> errors;
-
     @Override
-    public ClaimRequestWrapper getClaimRequest(String resourceUrl, String claimCode)
+    public Claim getClaimRequest(String resourceUrl, String claimCode)
             throws URISyntaxException {
         String url = resourceUrl + "/" + claimCode;
-        Claim receivedClaim = fhirRequestClient.getObject(url, Claim.class);
-        return wrapResponse(receivedClaim);
+        return fhirRequestClient.getObject(url, Claim.class);
     }
 
     @Override
@@ -54,37 +39,11 @@ public class ClaimHttpRequestImpl implements ClaimHttpRequest {
         return fhirRequestClient.getObject(url, ClaimResponse.class);
     }
 
-    @Override
-    public List<String> getErrors() {
-        return errors != null ? errors : Collections.emptyList();
-    }
-
     public void setFhirInsuranceClaimService(FHIRInsuranceClaimService fhirInsuranceClaimService) {
         this.fhirInsuranceClaimService = fhirInsuranceClaimService;
-    }
-
-    public void setFhirClaimDiagnosisService(FHIRClaimDiagnosisService fhirClaimDiagnosisService) {
-        this.fhirClaimDiagnosisService = fhirClaimDiagnosisService;
-    }
-
-    public void setFhirClaimItemService(FHIRClaimItemService fhirClaimItemService) {
-        this.fhirClaimItemService = fhirClaimItemService;
     }
 
     public void setFhirRequestClient(FHIRClient fhirRequestClient) {
         this.fhirRequestClient = fhirRequestClient;
     }
-
-    private ClaimRequestWrapper wrapResponse(Claim claim) {
-        this.errors = new ArrayList<>();
-
-        InsuranceClaim receivedClaim = fhirInsuranceClaimService.generateOmrsClaim(claim, errors);
-        List<InsuranceClaimDiagnosis> receivedDiagnosis = claim.getDiagnosis().stream()
-                .map(diagnosis -> fhirClaimDiagnosisService.createOmrsClaimDiagnosis(diagnosis, errors))
-                .collect(Collectors.toList());
-        List<InsuranceClaimItem> items = fhirClaimItemService.generateOmrsClaimItems(claim, errors);
-
-        return new ClaimRequestWrapper(receivedClaim, receivedDiagnosis, items);
-    }
-
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimRequestWrapper.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/client/impl/ClaimRequestWrapper.java
@@ -11,12 +11,21 @@ public class ClaimRequestWrapper {
     private InsuranceClaim insuranceClaim;
     private List<InsuranceClaimDiagnosis> diagnosis;
     private List<InsuranceClaimItem> items;
+    private List<String> errors;
 
     public ClaimRequestWrapper(InsuranceClaim claim, List<InsuranceClaimDiagnosis> diagnosis,
     List<InsuranceClaimItem> items) {
         this.insuranceClaim = claim;
         this.diagnosis = diagnosis;
         this.items = items;
+    }
+
+    public ClaimRequestWrapper(InsuranceClaim claim, List<InsuranceClaimDiagnosis> diagnosis,
+    List<InsuranceClaimItem> items, List<String> errors) {
+        this.insuranceClaim = claim;
+        this.diagnosis = diagnosis;
+        this.items = items;
+        this.errors = errors;
     }
 
     public InsuranceClaim getInsuranceClaim() {
@@ -49,5 +58,13 @@ public class ClaimRequestWrapper {
 
     public void addItem(InsuranceClaimItem item) {
         this.items.add(item);
+    }
+
+    public void setErrors(List<String> errors) {
+        this.errors = errors;
+    }
+
+    public List<String> getErrors() {
+        return errors;
     }
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimUtil.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimUtil.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.insuranceclaims.api.service.fhir.util;
 
 import org.hl7.fhir.dstu3.model.Claim;
+import org.hl7.fhir.dstu3.model.ClaimResponse;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Period;
@@ -86,6 +87,11 @@ public final class InsuranceClaimUtil {
 
     public static String getClaimUuid(Claim claim, List<String> errors) {
         return getIdentifierValueByCode(claim, ACCESSION_ID, errors);
+    }
+
+    public static String getClaimResponseId(ClaimResponse claimResponse) {
+        //Claim ID should be in format "ClaimResponse/claimId";
+        return claimResponse.getId().split("/")[1];
     }
 
     public static Date getClaimDateCreated(Claim claim, List<String> errors) {

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ClaimRequestException.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ClaimRequestException.java
@@ -6,6 +6,8 @@ public class ClaimRequestException extends Exception {
         super(message);
     }
 
-    public ClaimRequestException(String message, Throwable cause) { super(message, cause); }
+    public ClaimRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ClaimRequestException.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ClaimRequestException.java
@@ -1,0 +1,11 @@
+package org.openmrs.module.insuranceclaims.api.service.request;
+
+public class ClaimRequestException extends Exception {
+
+    public ClaimRequestException(String message) {
+        super(message);
+    }
+
+    public ClaimRequestException(String message, Throwable cause) { super(message, cause); }
+
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ExternalApiRequest.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ExternalApiRequest.java
@@ -6,14 +6,11 @@ import org.openmrs.module.insuranceclaims.api.client.impl.ClaimRequestWrapper;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
 
 import java.net.URISyntaxException;
-import java.util.List;
 
 public interface ExternalApiRequest {
     ClaimRequestWrapper getClaimFromExternalApi(String claimCode) throws URISyntaxException;
 
     ClaimRequestWrapper getClaimResponseFromExternalApi(String claimCode) throws URISyntaxException, FHIRException;
 
-    ClaimResponse sendClaimToExternalApi(InsuranceClaim claim) throws URISyntaxException, FHIRException;
-
-    List<String> getErrors();
+    ClaimResponse sendClaimToExternalApi(InsuranceClaim claim) throws ClaimRequestException;
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ExternalApiRequest.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ExternalApiRequest.java
@@ -1,0 +1,19 @@
+package org.openmrs.module.insuranceclaims.api.service.request;
+
+import org.hl7.fhir.dstu3.model.ClaimResponse;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.openmrs.module.insuranceclaims.api.client.impl.ClaimRequestWrapper;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+public interface ExternalApiRequest {
+    ClaimRequestWrapper getClaimFromExternalApi(String claimCode) throws URISyntaxException;
+
+    ClaimRequestWrapper getClaimResponseFromExternalApi(String claimCode) throws URISyntaxException, FHIRException;
+
+    ClaimResponse sendClaimToExternalApi(InsuranceClaim claim) throws URISyntaxException, FHIRException;
+
+    List<String> getErrors();
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
@@ -102,6 +102,10 @@ public class ExternalApiRequestImpl implements ExternalApiRequest {
         this.fhirClaimDiagnosisService = fhirClaimDiagnosisService;
     }
 
+    public void setInsuranceClaimService(InsuranceClaimService insuranceClaimService) {
+        this.insuranceClaimService = insuranceClaimService;
+    }
+
     private void setUrls() {
         String baseUrl = Context.getAdministrationService().getGlobalProperty(BASE_URL_PROPERTY);
         String claimUri =  Context.getAdministrationService().getGlobalProperty(CLAIM_SOURCE_URI);

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
@@ -1,0 +1,123 @@
+package org.openmrs.module.insuranceclaims.api.service.request.impl;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.hl7.fhir.dstu3.model.Claim;
+import org.hl7.fhir.dstu3.model.ClaimResponse;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.insuranceclaims.api.client.ClaimHttpRequest;
+import org.openmrs.module.insuranceclaims.api.client.impl.ClaimRequestWrapper;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimDiagnosis;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimDiagnosisService;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimItemService;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimResponseService;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRInsuranceClaimService;
+import org.openmrs.module.insuranceclaims.api.service.request.ExternalApiRequest;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.openmrs.module.insuranceclaims.api.client.ClientConstants.BASE_URL_PROPERTY;
+import static org.openmrs.module.insuranceclaims.api.client.ClientConstants.CLAIM_RESPONSE_SOURCE_URI;
+import static org.openmrs.module.insuranceclaims.api.client.ClientConstants.CLAIM_SOURCE_URI;
+
+public class ExternalApiRequestImpl implements ExternalApiRequest {
+
+    private String claimResponseUrl;
+    private String claimUrl;
+
+    private ClaimHttpRequest claimHttpRequest;
+
+    private FHIRInsuranceClaimService fhirInsuranceClaimService;
+
+    private FHIRClaimItemService fhirClaimItemService;
+
+    private FHIRClaimResponseService fhirClaimResponseService;
+
+    private FHIRClaimDiagnosisService fhirClaimDiagnosisService;
+
+    @SuppressFBWarnings("UWF_UNWRITTEN_FIELD")
+    private List<String> errors;
+
+    @Override
+    public ClaimRequestWrapper getClaimFromExternalApi(String claimCode) throws URISyntaxException {
+        setUrls();
+        Claim claim = claimHttpRequest.getClaimRequest(this.claimUrl, claimCode);
+        return wrapResponse(claim);
+    }
+
+    @Override
+    public ClaimRequestWrapper getClaimResponseFromExternalApi(String claimCode) throws URISyntaxException, FHIRException {
+        setUrls();
+        ClaimResponse response = claimHttpRequest.getClaimResponse(this.claimResponseUrl, claimCode);
+        return wrapResponse(response);
+    }
+
+    @Override
+    public ClaimResponse sendClaimToExternalApi(InsuranceClaim claim) throws URISyntaxException,
+            FHIRException {
+        setUrls();
+        return claimHttpRequest.sendClaimRequest(claimUrl, claim);
+    }
+
+    @Override
+    public List<String> getErrors() {
+        return errors != null ? errors : Collections.emptyList();
+    }
+
+    public void setClaimHttpRequest(ClaimHttpRequest claimHttpRequest) {
+        this.claimHttpRequest = claimHttpRequest;
+    }
+
+    public void setFhirInsuranceClaimService(FHIRInsuranceClaimService fhirInsuranceClaimService) {
+        this.fhirInsuranceClaimService = fhirInsuranceClaimService;
+    }
+
+    public void setFhirClaimItemService(FHIRClaimItemService fhirClaimItemService) {
+        this.fhirClaimItemService = fhirClaimItemService;
+    }
+
+    public void setFhirClaimResponseService(FHIRClaimResponseService fhirClaimResponseService) {
+        this.fhirClaimResponseService = fhirClaimResponseService;
+    }
+
+    public void setFhirClaimDiagnosisService(FHIRClaimDiagnosisService fhirClaimDiagnosisService) {
+        this.fhirClaimDiagnosisService = fhirClaimDiagnosisService;
+    }
+
+    private void setUrls() {
+        String baseUrl = Context.getAdministrationService().getGlobalProperty(BASE_URL_PROPERTY);
+        String claimUri =  Context.getAdministrationService().getGlobalProperty(CLAIM_SOURCE_URI);
+        String claimResponseUri =  Context.getAdministrationService().getGlobalProperty(CLAIM_RESPONSE_SOURCE_URI);
+
+        this.claimResponseUrl = baseUrl + "/" + claimResponseUri;
+        this.claimUrl = baseUrl + "/" + claimUri;
+        System.out.println("Claim urls: ");
+        System.out.println("Claim Response url: " + claimResponseUrl);
+        System.out.println("Claim Url: " + claimUrl);
+    }
+
+    private ClaimRequestWrapper wrapResponse(Claim claim) {
+        this.errors = new ArrayList<>();
+        InsuranceClaim receivedClaim = fhirInsuranceClaimService.generateOmrsClaim(claim, errors);
+        List<InsuranceClaimDiagnosis> receivedDiagnosis = claim.getDiagnosis().stream()
+                .map(diagnosis -> fhirClaimDiagnosisService.createOmrsClaimDiagnosis(diagnosis, errors))
+                .collect(Collectors.toList());
+        List<InsuranceClaimItem> items = fhirClaimItemService.generateOmrsClaimItems(claim, errors);
+
+        return new ClaimRequestWrapper(receivedClaim, receivedDiagnosis, items);
+    }
+
+    private ClaimRequestWrapper wrapResponse(ClaimResponse claim) throws FHIRException {
+        this.errors = new ArrayList<>();
+        InsuranceClaim receivedClaim = fhirClaimResponseService.generateOmrsClaim(claim, errors);
+        List<InsuranceClaimItem> items = fhirClaimItemService.generateOmrsClaimResponseItems(claim, errors);
+
+        return new ClaimRequestWrapper(receivedClaim, null, items);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
@@ -97,9 +97,6 @@ public class ExternalApiRequestImpl implements ExternalApiRequest {
 
         this.claimResponseUrl = baseUrl + "/" + claimResponseUri;
         this.claimUrl = baseUrl + "/" + claimUri;
-        System.out.println("Claim urls: ");
-        System.out.println("Claim Response url: " + claimResponseUrl);
-        System.out.println("Claim Url: " + claimUrl);
     }
 
     private ClaimRequestWrapper wrapResponse(Claim claim) {

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
@@ -123,7 +123,7 @@ public class ExternalApiRequestImpl implements ExternalApiRequest {
                 .collect(Collectors.toList());
         List<InsuranceClaimItem> items = fhirClaimItemService.generateOmrsClaimItems(claim, errors);
 
-        return new ClaimRequestWrapper(receivedClaim, receivedDiagnosis, items);
+        return new ClaimRequestWrapper(receivedClaim, receivedDiagnosis, items, errors);
     }
 
     private ClaimRequestWrapper wrapResponse(ClaimResponse claim) throws FHIRException {
@@ -131,6 +131,6 @@ public class ExternalApiRequestImpl implements ExternalApiRequest {
         InsuranceClaim receivedClaim = fhirClaimResponseService.generateOmrsClaim(claim, errors);
         List<InsuranceClaimItem> items = fhirClaimItemService.generateOmrsClaimResponseItems(claim, errors);
 
-        return new ClaimRequestWrapper(receivedClaim, null, items);
+        return new ClaimRequestWrapper(receivedClaim, null, items, errors);
     }
 }

--- a/api/src/main/resources/components/clientComponents.xml
+++ b/api/src/main/resources/components/clientComponents.xml
@@ -23,5 +23,6 @@
         <property name="fhirClaimResponseService"  ref="insuranceclaims.FHIRClaimResponseService"/>
         <property name="fhirClaimDiagnosisService" ref="insuranceclaims.FHIRClaimDiagnosisService"/>
         <property name="fhirClaimItemService"      ref="insuranceclaims.FHIRClaimItemService"/>
+        <property name="insuranceClaimService"     ref="insuranceclaims.InsuranceClaimService"/>
     </bean>
 </beans>

--- a/api/src/main/resources/components/clientComponents.xml
+++ b/api/src/main/resources/components/clientComponents.xml
@@ -13,8 +13,15 @@
     <bean id="insuranceclaims.ClaimHttpRequest"
           class="org.openmrs.module.insuranceclaims.api.client.impl.ClaimHttpRequestImpl">
         <property name="fhirInsuranceClaimService" ref="insuranceclaims.FHIRInsuranceClaimService"/>
+        <property name="fhirRequestClient"         ref="insuranceclaims.FhirRequest" />
+    </bean>
+
+    <bean id="insuranceclaims.ExternalApiRequest"
+          class="org.openmrs.module.insuranceclaims.api.service.request.impl.ExternalApiRequestImpl">
+        <property name="claimHttpRequest" ref="insuranceclaims.ClaimHttpRequest" />
+        <property name="fhirInsuranceClaimService" ref="insuranceclaims.FHIRInsuranceClaimService"/>
+        <property name="fhirClaimResponseService"  ref="insuranceclaims.FHIRClaimResponseService"/>
         <property name="fhirClaimDiagnosisService" ref="insuranceclaims.FHIRClaimDiagnosisService"/>
         <property name="fhirClaimItemService"      ref="insuranceclaims.FHIRClaimItemService"/>
-        <property name="fhirRequestClient"         ref="insuranceclaims.FhirRequest" />
     </bean>
 </beans>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -76,5 +76,4 @@
             </list>
         </property>
     </bean>
-
 </beans>

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/utils/InsuranceClaimUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/utils/InsuranceClaimUtilTest.java
@@ -42,16 +42,10 @@ public class InsuranceClaimUtilTest extends BaseModuleContextSensitiveTest {
     private static final String TEST_UUID = "T3STUU1D";
 
     @Autowired
-    InsuranceClaimService insuranceClaimService;
+    private InsuranceClaimService insuranceClaimService;
 
     @Autowired
-    FHIRInsuranceClaimService fhirInsuranceClaimService;
-
-    @Test
-    public void createClaimVisitType_shouldCreateValidCodeableConcept() {
-        CodeableConcept visitConcept = InsuranceClaimUtil.createClaimVisitType(testClaim);
-        Assert.assertThat(visitConcept.getText(), Matchers.equalTo(testClaim.getVisitType().getName()));
-    }
+    private FHIRInsuranceClaimService fhirInsuranceClaimService;
 
     @Before
     public void setUp() throws Exception {
@@ -60,6 +54,13 @@ public class InsuranceClaimUtilTest extends BaseModuleContextSensitiveTest {
         insuranceClaimService.saveOrUpdate(testClaim);
         mappedClaim = fhirInsuranceClaimService.generateClaim(testClaim);
     }
+
+    @Test
+    public void createClaimVisitType_shouldCreateValidCodeableConcept() {
+        CodeableConcept visitConcept = InsuranceClaimUtil.createClaimVisitType(testClaim);
+        Assert.assertThat(visitConcept.getText(), Matchers.equalTo(testClaim.getVisitType().getName()));
+    }
+
 
     @Test
     public void getClaimBillablePeriod_shouldReturnValidFromToDates() {

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/utils/InsuranceClaimUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/utils/InsuranceClaimUtilTest.java
@@ -1,0 +1,128 @@
+package org.openmrs.module.insuranceclaims.api.service.utils;
+
+import org.hamcrest.Matchers;
+import org.hl7.fhir.dstu3.model.Claim;
+import org.hl7.fhir.dstu3.model.ClaimResponse;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Location;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.Provider;
+import org.openmrs.VisitType;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+import org.openmrs.module.insuranceclaims.api.mother.InsuranceClaimMother;
+import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimService;
+import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRInsuranceClaimService;
+import org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimUtil;
+import org.openmrs.module.insuranceclaims.api.util.TestConstants;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.PATIENT_EXTERNAL_ID_IDENTIFIER_UUID;
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.PERIOD_FROM;
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.PERIOD_TO;
+import static org.openmrs.module.insuranceclaims.api.util.TestConstants.EXTERNAL_ID_DATASET_PATH;
+
+public class InsuranceClaimUtilTest extends BaseModuleContextSensitiveTest {
+
+    private InsuranceClaim testClaim;
+
+    private Claim mappedClaim;
+
+    private static InsuranceClaimUtil utils;
+
+    private static final String TEST_UUID = "T3STUU1D";
+
+    @Autowired
+    InsuranceClaimService insuranceClaimService;
+
+    @Autowired
+    FHIRInsuranceClaimService fhirInsuranceClaimService;
+
+    @Test
+    public void createClaimVisitType_shouldCreateValidCodeableConcept() {
+        CodeableConcept visitConcept = InsuranceClaimUtil.createClaimVisitType(testClaim);
+        Assert.assertThat(visitConcept.getText(), Matchers.equalTo(testClaim.getVisitType().getName()));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSet(EXTERNAL_ID_DATASET_PATH);
+        testClaim = createTestClaim();
+        insuranceClaimService.saveOrUpdate(testClaim);
+        mappedClaim = fhirInsuranceClaimService.generateClaim(testClaim);
+    }
+
+    @Test
+    public void getClaimBillablePeriod_shouldReturnValidFromToDates() {
+        List<String> errors = new ArrayList<>();
+        Map<String, Date> billablePeriod = InsuranceClaimUtil.getClaimBillablePeriod(mappedClaim, errors);
+
+        Assert.assertThat(billablePeriod.get(PERIOD_FROM), Matchers.equalTo(testClaim.getDateFrom()));
+        Assert.assertThat(billablePeriod.get(PERIOD_TO), Matchers.equalTo(testClaim.getDateTo()));
+    }
+
+    @Test
+    public void getClaimExplanation_shouldReturnClaimExplanation() {
+        List<String> errors = new ArrayList<>();
+        String explanation = InsuranceClaimUtil.getClaimExplanation(mappedClaim, errors);
+
+        Assert.assertThat(explanation, Matchers.equalTo(testClaim.getExplanation()));
+    }
+
+    @Test
+    public void getClaimGuaranteeId_shouldReturnGuaranteeId() {
+        List<String> errors = new ArrayList<>();
+        String guaranteeId = InsuranceClaimUtil.getClaimGuaranteeId(mappedClaim, errors);
+
+        Assert.assertThat(guaranteeId, Matchers.equalTo(testClaim.getGuaranteeId()));
+    }
+
+    @Test
+    public void getClaimCode_shouldReturnClaimCode() {
+        List<String> errors = new ArrayList<>();
+        String claimCode = InsuranceClaimUtil.getClaimCode(mappedClaim, errors);
+
+        Assert.assertThat(claimCode, Matchers.equalTo(testClaim.getClaimCode()));
+    }
+
+    @Test
+    public void getClaimUuid_shouldReturnClaimUuid() {
+        List<String> errors = new ArrayList<>();
+        String claimUuid = InsuranceClaimUtil.getClaimUuid(mappedClaim, errors);
+        Assert.assertThat(claimUuid, Matchers.equalTo(testClaim.getUuid()));
+    }
+
+    @Test
+    public void getClaimResponseId_shouldReturnResponseUuid() {
+        ClaimResponse response = new ClaimResponse();
+        response.setId("ClaimRepsonse/"+TEST_UUID);
+        String uuid = InsuranceClaimUtil.getClaimResponseId(response);
+        Assert.assertThat(uuid, Matchers.equalTo(TEST_UUID));
+    }
+
+    @Test
+    public void getClaimDateCreated() {
+        List<String> errors = new ArrayList<>();
+        Date dateCreated = InsuranceClaimUtil.getClaimDateCreated(mappedClaim, errors);
+
+        Assert.assertThat(dateCreated, Matchers.equalTo(testClaim.getDateCreated()));
+    }
+
+    private InsuranceClaim createTestClaim() {
+        Location location = Context.getLocationService().getLocation(TestConstants.TEST_LOCATION_ID);
+        Provider provider = Context.getProviderService().getProvider(TestConstants.TEST_PROVIDER_ID);
+        VisitType visitType = Context.getVisitService().getVisitType(TestConstants.TEST_VISIT_TYPE_ID);
+        PatientIdentifierType identifierType = Context.getPatientService()
+                .getPatientIdentifierTypeByUuid(PATIENT_EXTERNAL_ID_IDENTIFIER_UUID);
+        return InsuranceClaimMother.createTestInstance(location, provider, visitType, identifierType);
+    }
+}

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/utils/InsuranceClaimUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/utils/InsuranceClaimUtilTest.java
@@ -61,7 +61,6 @@ public class InsuranceClaimUtilTest extends BaseModuleContextSensitiveTest {
         Assert.assertThat(visitConcept.getText(), Matchers.equalTo(testClaim.getVisitType().getName()));
     }
 
-
     @Test
     public void getClaimBillablePeriod_shouldReturnValidFromToDates() {
         List<String> errors = new ArrayList<>();

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/InsuranceClaimsOmodConstants.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/InsuranceClaimsOmodConstants.java
@@ -3,7 +3,7 @@ package org.openmrs.module.insuranceclaims;
 public final class InsuranceClaimsOmodConstants {
 
     public static final String CLAIM_NOT_FOUND_MESSAGE = "Claim not found";
-    public static final String CLAIM_NOT_SENT_MESSAGE = "Claim don't have external ID. It probably was not sent.";
-    public static final String CLAIM_ALREADY_SENT_MESSAGE = "Claim was alredy sent to external system";
+    public static final String CLAIM_NOT_SENT_MESSAGE = "Claim does not have have external ID. It was not sent.";
+    public static final String CLAIM_ALREADY_SENT_MESSAGE = "Claim has been already sent to external system";
     private InsuranceClaimsOmodConstants() { }
 }

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/InsuranceClaimsOmodConstants.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/InsuranceClaimsOmodConstants.java
@@ -1,0 +1,9 @@
+package org.openmrs.module.insuranceclaims;
+
+public final class InsuranceClaimsOmodConstants {
+
+    public static final String CLAIM_NOT_FOUND_MESSAGE = "Claim not found";
+    public static final String CLAIM_NOT_SENT_MESSAGE = "Claim don't have external ID. It probably was not sent.";
+    public static final String CLAIM_ALREADY_SENT_MESSAGE = "Claim was alredy sent to external system";
+    private InsuranceClaimsOmodConstants() { }
+}

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
@@ -9,6 +9,8 @@ import org.openmrs.module.insuranceclaims.api.service.request.ExternalApiRequest
 import org.openmrs.module.insuranceclaims.forms.ClaimFormService;
 import org.openmrs.module.insuranceclaims.forms.NewClaimForm;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +31,11 @@ import static org.openmrs.module.insuranceclaims.InsuranceClaimsOmodConstants.CL
 @RestController
 @RequestMapping(value = "insuranceclaims/rest/v1/claims")
 public class InsuranceClaimResourceController {
+
+    /**
+     * Logger for this class and subclasses
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(InsuranceClaimsController.class);
 
     @Autowired
     private ClaimFormService claimFormService;
@@ -81,7 +88,7 @@ public class InsuranceClaimResourceController {
             responseEntity = new ResponseEntity<>(claim, HttpStatus.EXPECTATION_FAILED);
 
             if (!externalApiRequest.getErrors().isEmpty()) {
-                System.out.println("Insurance claim: Errors during processing: " + externalApiRequest.getErrors().toString());
+                LOG.info("Insurance claim: Errors during processing: " + externalApiRequest.getErrors().toString());
             }
         } catch (URISyntaxException | FHIRException requestException) {
             String exceptionMessage = "Exception occured during processing request: "
@@ -91,7 +98,6 @@ public class InsuranceClaimResourceController {
             String exceptionMessage = "Exception occured during processing request: "
                     + "Message:" + e.getMessage()
                     + "Reason: " + e.getResponseBodyAsString();
-            System.out.println(exceptionMessage);
             responseEntity = new ResponseEntity<>(exceptionMessage, HttpStatus.EXPECTATION_FAILED);
         }
         return responseEntity;

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
@@ -57,12 +57,11 @@ public class InsuranceClaimResourceController {
     }
 
     /**
-     * @param claimUuid uuid of claim that will be send to external server
-     * @return InsuranceClaim with updated values or error message that occured during processing request
-     *
-     * This method will check if claim is present in external id, if external id does not have information about this
+     * Checks if claim is present in external id, if external id does not have information about this
      * claim it will send it to external system, if claim was already submitted it will get update object based on external
      * information.
+     * @param claimUuid uuid of claim that will be send to external server
+     * @return InsuranceClaim with updated values or error message that occured during processing request
      */
     @RequestMapping(value = "/sendToExternal", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
@@ -97,5 +96,4 @@ public class InsuranceClaimResourceController {
 
         return requestResponse;
     }
-
 }

--- a/omod/src/main/webapp/pages/addClaim.gsp
+++ b/omod/src/main/webapp/pages/addClaim.gsp
@@ -96,12 +96,12 @@
                 def details = "Details"
                 def itemDetailsId = item.key + details %>
 
-                <tr> <div id="${item.key}" style="cursor: pointer;"> ConceptName : ${item.key} </div> </tr>
+                <tr> <div id="${item.key}" style="cursor: pointer;"> ${index + 1}. ${item.key} </div> </tr>
                 <div id="${itemDetailsId}" style="display: none;">
-                    <%item.value.each { providedItem -> %>
+                    <%item.value.eachWithIndex { providedItem, itemIndex -> %>
                         <tr>
                             <div class="consumedItemsOfType" id="${providedItem.uuid}" style="border: 2px solid black;">
-                                ${index}. ${providedItem.dateOfServed} 
+                                ${itemIndex + 1}. ${providedItem.dateOfServed} 
                             </div>
                             <script>
                                 providedItems['${item.key}'] = {};
@@ -144,7 +144,7 @@
                         }
                     };
                 </script>
-                -----------<br/>
+                <br/>
             <% } %>
         </tr>
         <br />
@@ -246,14 +246,14 @@
         url: "../ws/insuranceclaims/rest/v1/claims",
         success: function(){alert("It worked!")},
         error: function (request, status, error) {
-            document.getElementById("formData").innerHTML = JSON.stringify(request) + JSON.stringify(status) + JSON.stringify(error);
+            document.getElementById("formData").innerHTML = request;
         },
         dataType: "json",
         contentType : "application/json"
         }).done(function(data) {
                 // log data to the console so we can see
                 console.log(data); 
-                document.getElementById("formData").innerHTML = JSON.stringify(data);
+                document.getElementById("formData").innerHTML = data;
                 // here we will handle errors and validation messages
             });
     }


### PR DESCRIPTION
### SUMMARY
This PR adds new endpoint on /ws/insuranceclaims/rest/v1/claims/sendToExternal?claimId={uuid}, that allows user to send insurance claim that corresponds to the uuid given in the parameter. The url to which the claim is sent depends on global properties.