### PR TITLE
ICLM-32: Added endpoint for updating claim with external service data 

### DIFF
--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/InsuranceClaimItemService.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/InsuranceClaimItemService.java
@@ -1,7 +1,14 @@
 package org.openmrs.module.insuranceclaims.api.service;
 
+import javassist.NotFoundException;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
+
+import java.util.List;
 
 public interface InsuranceClaimItemService extends OpenmrsDataService<InsuranceClaimItem> {
 
+    InsuranceClaimItem updateInsuranceClaimItem(InsuranceClaimItem itemToUpdate, InsuranceClaimItem itemUpdated);
+
+    List<InsuranceClaimItem> updateInsuranceClaimItems(List<InsuranceClaimItem> itemsToUpdate,
+                                                       List<InsuranceClaimItem> itemsUpdated) throws NotFoundException;
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/InsuranceClaimItemService.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/InsuranceClaimItemService.java
@@ -1,7 +1,7 @@
 package org.openmrs.module.insuranceclaims.api.service;
 
-import javassist.NotFoundException;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
+import org.openmrs.module.insuranceclaims.api.service.exceptions.ItemMatchingFailedException;
 
 import java.util.List;
 
@@ -10,5 +10,5 @@ public interface InsuranceClaimItemService extends OpenmrsDataService<InsuranceC
     InsuranceClaimItem updateInsuranceClaimItem(InsuranceClaimItem itemToUpdate, InsuranceClaimItem itemUpdated);
 
     List<InsuranceClaimItem> updateInsuranceClaimItems(List<InsuranceClaimItem> itemsToUpdate,
-                                                       List<InsuranceClaimItem> itemsUpdated) throws NotFoundException;
+                                                       List<InsuranceClaimItem> itemsUpdated) throws ItemMatchingFailedException;
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/InsuranceClaimService.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/InsuranceClaimService.java
@@ -4,4 +4,5 @@ import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
 
 public interface InsuranceClaimService extends OpenmrsDataService<InsuranceClaim> {
 
+    InsuranceClaim updateClaim(InsuranceClaim claimToUpdate, InsuranceClaim updatedClaim);
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/exceptions/ClaimRequestException.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/exceptions/ClaimRequestException.java
@@ -1,4 +1,4 @@
-package org.openmrs.module.insuranceclaims.api.service.request;
+package org.openmrs.module.insuranceclaims.api.service.exceptions;
 
 public class ClaimRequestException extends Exception {
 
@@ -9,5 +9,4 @@ public class ClaimRequestException extends Exception {
     public ClaimRequestException(String message, Throwable cause) {
         super(message, cause);
     }
-
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/exceptions/ItemMatchingFailedException.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/exceptions/ItemMatchingFailedException.java
@@ -1,0 +1,12 @@
+package org.openmrs.module.insuranceclaims.api.service.exceptions;
+
+public class ItemMatchingFailedException extends Exception {
+
+    public ItemMatchingFailedException(String message) {
+        super(message);
+    }
+
+    public ItemMatchingFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/FHIRClaimItemService.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/FHIRClaimItemService.java
@@ -9,6 +9,8 @@ import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
 import java.util.List;
 
 public interface FHIRClaimItemService {
+    Claim assignItemsWithInformationToClaim(Claim fhirClaim, InsuranceClaim claim);
+
     List<Claim.ItemComponent> generateClaimItemComponent(InsuranceClaim claim);
 
     List<Claim.ItemComponent> generateClaimItemComponent(List<InsuranceClaimItem> claim);

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/impl/FHIRInsuranceClaimServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/impl/FHIRInsuranceClaimServiceImpl.java
@@ -101,7 +101,7 @@ public class FHIRInsuranceClaimServiceImpl implements FHIRInsuranceClaimService 
         //Set type
         claim.setType(createClaimVisitType(omrsClaim));
         //Set items
-        claim.setItem(claimItemService.generateClaimItemComponent(omrsClaim));
+        claimItemService.assignItemsWithInformationToClaim(claim, omrsClaim);
 
         //Set diagnosis
         claim.setDiagnosis(claimDiagnosisService.generateClaimDiagnosisComponent(omrsClaim));

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimConstants.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimConstants.java
@@ -41,6 +41,7 @@ public final class InsuranceClaimConstants {
 
     public static final String GUARANTEE_ID_CATEGORY = "guarantee_id";
     public static final String EXPLANATION_CATEGORY = "explanation";
+    public static final String ITEM_EXPLANATION_CATEGORY = "item_explanation";
 
     public static final String CONTRACT = "Contract";
     public static final int CONTRACT_POLICY_ID_ORDINAL = 1;

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimItemUtil.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimItemUtil.java
@@ -147,16 +147,7 @@ public final class InsuranceClaimItemUtil {
                 .collect(Collectors.toList());
     }
 
-    private static String getAdjustedReason(CodeableConcept concept) {
-        return StringUtils.upperCase(concept.getText());
-    }
-
-    private static boolean isValueInSequence(List<PositiveIntType> sequence, int sequenceLinkId) {
-        return sequence.stream().map(PrimitiveType::getValue)
-                .anyMatch(value -> value.equals(sequenceLinkId));
-    }
-
-    private static String getExternalCode(Concept concept) {
+    public static String getExternalCode(Concept concept) {
         Collection<ConceptMap> mappings = concept.getConceptMappings();
         return mappings
                 .stream()
@@ -164,6 +155,15 @@ public final class InsuranceClaimItemUtil {
                 .map(c -> c.getConceptReferenceTerm().getCode())
                 .findFirst()
                 .orElse(null);
+    }
+
+    private static String getAdjustedReason(CodeableConcept concept) {
+        return StringUtils.upperCase(concept.getText());
+    }
+
+    private static boolean isValueInSequence(List<PositiveIntType> sequence, int sequenceLinkId) {
+        return sequence.stream().map(PrimitiveType::getValue)
+                .anyMatch(value -> value.equals(sequenceLinkId));
     }
 
     private static String getConceptCategory(Concept concept) {

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/PatientUtil.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/PatientUtil.java
@@ -13,7 +13,7 @@ public final class PatientUtil {
 
     public static Reference buildPatientReference(InsuranceClaim claim) {
         Patient patient = claim.getPatient();
-        Reference patientReference = FHIRUtils.buildPractitionerReference(claim.getProvider());
+        Reference patientReference = FHIRUtils.buildPatientOrPersonResourceReference(claim.getPatient());
 
         String patientId = patient.getActiveIdentifiers()
                 .stream()

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsuranceClaimItemServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsuranceClaimItemServiceImpl.java
@@ -1,13 +1,14 @@
 package org.openmrs.module.insuranceclaims.api.service.impl;
 
-import javassist.NotFoundException;
 import org.hl7.fhir.dstu3.model.Money;
 import org.openmrs.Concept;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItemStatus;
 import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimItemService;
+import org.openmrs.module.insuranceclaims.api.service.exceptions.ItemMatchingFailedException;
 import org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimItemUtil;
 
+import javax.transaction.Transactional;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +18,7 @@ public class InsuranceClaimItemServiceImpl extends BaseOpenmrsDataService<Insura
         implements InsuranceClaimItemService {
 
     @Override
+    @Transactional
     public InsuranceClaimItem updateInsuranceClaimItem(InsuranceClaimItem itemToUpdate, InsuranceClaimItem itemUpdated) {
         itemToUpdate.setStatus(itemUpdated.getStatus());
         itemToUpdate.setRejectionReason(itemUpdated.getRejectionReason());
@@ -29,8 +31,9 @@ public class InsuranceClaimItemServiceImpl extends BaseOpenmrsDataService<Insura
     }
 
     @Override
+    @Transactional
     public List<InsuranceClaimItem> updateInsuranceClaimItems(List<InsuranceClaimItem> itemsToUpdate,
-                                                        List<InsuranceClaimItem> itemsWithUpdates) throws NotFoundException {
+                                                        List<InsuranceClaimItem> itemsWithUpdates) throws ItemMatchingFailedException {
         List<InsuranceClaimItem> itemsUpdatedCopy = new ArrayList<>(itemsWithUpdates);
         for (InsuranceClaimItem item: itemsToUpdate) {
             String itemCode = getClaimItemCode(item);
@@ -43,7 +46,7 @@ public class InsuranceClaimItemServiceImpl extends BaseOpenmrsDataService<Insura
 
         if (!itemsUpdatedCopy.isEmpty()) {
             String unusedUpdatedItemCodes = itemsUpdatedCopy.stream().map(item -> getClaimItemCode(item)).collect(Collectors.joining());
-            throw new NotFoundException("Could not update items, failed to match updated item with codes: " + unusedUpdatedItemCodes);
+            throw new ItemMatchingFailedException("Could not update items, failed to match updated item with codes: " + unusedUpdatedItemCodes);
         }
 
         itemsToUpdate.forEach(this::saveOrUpdate);
@@ -76,12 +79,12 @@ public class InsuranceClaimItemServiceImpl extends BaseOpenmrsDataService<Insura
         }
     }
 
-    private InsuranceClaimItem findFirstMatchingItem(String itemExternalCode, int quantityProvided, Money unitPrice, List<InsuranceClaimItem> items) throws NotFoundException {
+    private InsuranceClaimItem findFirstMatchingItem(String itemExternalCode, int quantityProvided, Money unitPrice, List<InsuranceClaimItem> items) throws ItemMatchingFailedException {
         return items.stream()
                 .filter(item -> getClaimItemCode(item).equals(itemExternalCode))
                 .filter(item -> item.getQuantityProvided() == quantityProvided)
                 .filter(item -> InsuranceClaimItemUtil.getItemUnitPrice(item).equalsDeep(unitPrice))
                 .findFirst()
-                .orElseThrow(() -> new NotFoundException("Could not find match for item with code " + itemExternalCode));
+                .orElseThrow(() -> new ItemMatchingFailedException("Could not find match for item with code " + itemExternalCode));
     }
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsuranceClaimItemServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsuranceClaimItemServiceImpl.java
@@ -1,9 +1,87 @@
 package org.openmrs.module.insuranceclaims.api.service.impl;
 
+import javassist.NotFoundException;
+import org.hl7.fhir.dstu3.model.Money;
+import org.openmrs.Concept;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItemStatus;
 import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimItemService;
+import org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimItemUtil;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class InsuranceClaimItemServiceImpl extends BaseOpenmrsDataService<InsuranceClaimItem>
         implements InsuranceClaimItemService {
 
+    @Override
+    public InsuranceClaimItem updateInsuranceClaimItem(InsuranceClaimItem itemToUpdate, InsuranceClaimItem itemUpdated) {
+        itemToUpdate.setStatus(itemUpdated.getStatus());
+        itemToUpdate.setRejectionReason(itemUpdated.getRejectionReason());
+        itemToUpdate.setJustification(itemUpdated.getJustification());
+        updateQuantityApproved(itemToUpdate, itemUpdated);
+        updatePriceApproved(itemToUpdate, itemUpdated);
+        saveOrUpdate(itemToUpdate);
+
+        return itemToUpdate;
+    }
+
+    @Override
+    public List<InsuranceClaimItem> updateInsuranceClaimItems(List<InsuranceClaimItem> itemsToUpdate,
+                                                        List<InsuranceClaimItem> itemsWithUpdates) throws NotFoundException {
+        List<InsuranceClaimItem> itemsUpdatedCopy = new ArrayList<>(itemsWithUpdates);
+        for (InsuranceClaimItem item: itemsToUpdate) {
+            String itemCode = getClaimItemCode(item);
+            int quantityProvided = item.getQuantityProvided();
+            Money unitPrice = InsuranceClaimItemUtil.getItemUnitPrice(item);
+            InsuranceClaimItem matchingItemUpdated = findFirstMatchingItem(itemCode, quantityProvided, unitPrice, itemsUpdatedCopy);
+            updateInsuranceClaimItem(item, matchingItemUpdated);
+            itemsUpdatedCopy.remove(matchingItemUpdated);
+        }
+
+        if (!itemsUpdatedCopy.isEmpty()) {
+            String unusedUpdatedItemCodes = itemsUpdatedCopy.stream().map(item -> getClaimItemCode(item)).collect(Collectors.joining());
+            throw new NotFoundException("Could not update items, failed to match updated item with codes: " + unusedUpdatedItemCodes);
+        }
+
+        itemsToUpdate.forEach(this::saveOrUpdate);
+        return itemsToUpdate;
+    }
+
+    private String getClaimItemCode(InsuranceClaimItem item) {
+        Concept itemConcept = item.getItem().getItem();
+        return InsuranceClaimItemUtil.getExternalCode(itemConcept);
+    }
+
+    private void updateQuantityApproved(InsuranceClaimItem itemToUpdate, InsuranceClaimItem itemWithUpdate) {
+        Integer quantityApproved = itemWithUpdate.getQuantityApproved();
+        InsuranceClaimItemStatus status = itemWithUpdate.getStatus();
+        if (quantityApproved == null && status == InsuranceClaimItemStatus.PASSED) {
+            itemToUpdate.setQuantityApproved(itemToUpdate.getQuantityProvided());
+        } else {
+            itemToUpdate.setQuantityApproved(quantityApproved);
+        }
+    }
+
+    private void updatePriceApproved(InsuranceClaimItem itemToUpdate, InsuranceClaimItem itemWithUpdate) {
+        BigDecimal priceApproved = itemWithUpdate.getPriceApproved();
+        InsuranceClaimItemStatus status = itemWithUpdate.getStatus();
+        if (priceApproved == null && status == InsuranceClaimItemStatus.PASSED) {
+            Money conceptPrice = InsuranceClaimItemUtil.getItemUnitPrice(itemToUpdate);
+            itemToUpdate.setPriceApproved(conceptPrice.getValue());
+        } else {
+            itemToUpdate.setPriceApproved(priceApproved);
+        }
+    }
+
+    private InsuranceClaimItem findFirstMatchingItem(String itemExternalCode, int quantityProvided, Money unitPrice, List<InsuranceClaimItem> items) throws NotFoundException {
+        return items.stream()
+                .filter(item -> getClaimItemCode(item).equals(itemExternalCode))
+                .filter(item -> item.getQuantityProvided() == quantityProvided)
+                .filter(item -> InsuranceClaimItemUtil.getItemUnitPrice(item).equalsDeep(unitPrice))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("Could not find match for item with code " + itemExternalCode));
+    }
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsuranceClaimServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsuranceClaimServiceImpl.java
@@ -4,10 +4,12 @@ import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimStatus;
 import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimService;
 
+import javax.transaction.Transactional;
 import java.math.BigDecimal;
 
 public class InsuranceClaimServiceImpl extends BaseOpenmrsDataService<InsuranceClaim> implements InsuranceClaimService {
 
+    @Transactional
     public InsuranceClaim updateClaim(InsuranceClaim claimToUpdate, InsuranceClaim updatedClaim) {
         claimToUpdate.setAdjustment(updatedClaim.getAdjustment());
         updateQuantityApproved(claimToUpdate, updatedClaim);

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsuranceClaimServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsuranceClaimServiceImpl.java
@@ -1,8 +1,32 @@
 package org.openmrs.module.insuranceclaims.api.service.impl;
 
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimStatus;
 import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimService;
+
+import java.math.BigDecimal;
 
 public class InsuranceClaimServiceImpl extends BaseOpenmrsDataService<InsuranceClaim> implements InsuranceClaimService {
 
+    public InsuranceClaim updateClaim(InsuranceClaim claimToUpdate, InsuranceClaim updatedClaim) {
+        claimToUpdate.setAdjustment(updatedClaim.getAdjustment());
+        updateQuantityApproved(claimToUpdate, updatedClaim);
+        claimToUpdate.setDateProcessed(updatedClaim.getDateProcessed());
+        claimToUpdate.setRejectionReason(updatedClaim.getRejectionReason());
+        claimToUpdate.setStatus(updatedClaim.getStatus());
+
+        saveOrUpdate(claimToUpdate);
+
+        return claimToUpdate;
+    }
+
+    private void updateQuantityApproved(InsuranceClaim claimToUpdate, InsuranceClaim updatedClaim) {
+        BigDecimal totalBenefit = updatedClaim.getApprovedTotal();
+        InsuranceClaimStatus status = updatedClaim.getStatus();
+        if (totalBenefit == null && status == InsuranceClaimStatus.CHECKED) {
+            claimToUpdate.setApprovedTotal(claimToUpdate.getClaimedTotal());
+        } else {
+            claimToUpdate.setApprovedTotal(totalBenefit);
+        }
+    }
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsuranceClaimServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/impl/InsuranceClaimServiceImpl.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 public class InsuranceClaimServiceImpl extends BaseOpenmrsDataService<InsuranceClaim> implements InsuranceClaimService {
 
     @Transactional
+    @Override
     public InsuranceClaim updateClaim(InsuranceClaim claimToUpdate, InsuranceClaim updatedClaim) {
         claimToUpdate.setAdjustment(updatedClaim.getAdjustment());
         updateQuantityApproved(claimToUpdate, updatedClaim);

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ExternalApiRequest.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ExternalApiRequest.java
@@ -13,4 +13,6 @@ public interface ExternalApiRequest {
     ClaimRequestWrapper getClaimResponseFromExternalApi(String claimCode) throws URISyntaxException, FHIRException;
 
     ClaimResponse sendClaimToExternalApi(InsuranceClaim claim) throws ClaimRequestException;
+
+    InsuranceClaim updateClaim(InsuranceClaim claim) throws ClaimRequestException;
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ExternalApiRequest.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/ExternalApiRequest.java
@@ -4,6 +4,7 @@ import org.hl7.fhir.dstu3.model.ClaimResponse;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.openmrs.module.insuranceclaims.api.client.impl.ClaimRequestWrapper;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+import org.openmrs.module.insuranceclaims.api.service.exceptions.ClaimRequestException;
 
 import java.net.URISyntaxException;
 

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
@@ -1,5 +1,6 @@
 package org.openmrs.module.insuranceclaims.api.service.request.impl;
 
+import javassist.NotFoundException;
 import org.hl7.fhir.dstu3.model.Claim;
 import org.hl7.fhir.dstu3.model.ClaimResponse;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -9,7 +10,9 @@ import org.openmrs.module.insuranceclaims.api.client.impl.ClaimRequestWrapper;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimDiagnosis;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
+import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimItemService;
 import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimService;
+import org.openmrs.module.insuranceclaims.api.service.db.ItemDbService;
 import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimDiagnosisService;
 import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimItemService;
 import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimResponseService;
@@ -44,6 +47,10 @@ public class ExternalApiRequestImpl implements ExternalApiRequest {
     private FHIRClaimDiagnosisService fhirClaimDiagnosisService;
 
     private InsuranceClaimService insuranceClaimService;
+
+    private InsuranceClaimItemService insuranceClaimItemService;
+
+    private ItemDbService itemDbService;
 
     @Override
     public ClaimRequestWrapper getClaimFromExternalApi(String claimCode) throws URISyntaxException {
@@ -82,6 +89,32 @@ public class ExternalApiRequestImpl implements ExternalApiRequest {
         }
     }
 
+    @Override
+    public InsuranceClaim updateClaim(InsuranceClaim claim) throws ClaimRequestException {
+        try {
+            setUrls();
+            String claimExternalId = claim.getExternalId();
+            //For now it is assumed that external server don't have information that allows to match items
+            // in ClaimResponse with MRS concepts, but order of items in ClaimResponse is the same as in Claim
+            ClaimRequestWrapper wrappedResponse = getClaimResponseWithAssignedItemCodes(claimExternalId);
+            insuranceClaimService.updateClaim(claim, wrappedResponse.getInsuranceClaim());
+            List<InsuranceClaimItem> omrsItems = itemDbService.findInsuranceClaimItems(claim.getId());
+            insuranceClaimItemService.updateInsuranceClaimItems(omrsItems, wrappedResponse.getItems());
+
+            return claim;
+        } catch (URISyntaxException | FHIRException | NotFoundException requestException) {
+            String exceptionMessage = "Exception occured during processing request: "
+                    + "Message:" + requestException.getMessage();
+            throw new ClaimRequestException(exceptionMessage, requestException);
+        } catch (HttpServerErrorException e) {
+            String exceptionMessage = "Exception occured during processing request: "
+                    + "Message:" + e.getMessage()
+                    + "Reason: " + e.getResponseBodyAsString();
+
+            throw new ClaimRequestException(exceptionMessage, e);
+        }
+    }
+
     public void setClaimHttpRequest(ClaimHttpRequest claimHttpRequest) {
         this.claimHttpRequest = claimHttpRequest;
     }
@@ -104,6 +137,14 @@ public class ExternalApiRequestImpl implements ExternalApiRequest {
 
     public void setInsuranceClaimService(InsuranceClaimService insuranceClaimService) {
         this.insuranceClaimService = insuranceClaimService;
+    }
+
+    public void setInsuranceClaimItemService(InsuranceClaimItemService insuranceClaimItemService) {
+        this.insuranceClaimItemService = insuranceClaimItemService;
+    }
+
+    public void setItemDbService(ItemDbService itemDbService) {
+        this.itemDbService = itemDbService;
     }
 
     private void setUrls() {
@@ -132,5 +173,27 @@ public class ExternalApiRequestImpl implements ExternalApiRequest {
         List<InsuranceClaimItem> items = fhirClaimItemService.generateOmrsClaimResponseItems(claim, errors);
 
         return new ClaimRequestWrapper(receivedClaim, null, items, errors);
+    }
+
+    private ClaimRequestWrapper getClaimResponseWithAssignedItemCodes(String claimCode) throws URISyntaxException, FHIRException {
+        Claim claim = claimHttpRequest.getClaimRequest(this.claimUrl, claimCode);
+        ClaimResponse claimResponse = claimHttpRequest.getClaimResponse(this.claimResponseUrl, claimCode);
+
+        ClaimRequestWrapper wrappedResponse = wrapResponse(claimResponse);
+
+        List<InsuranceClaimItem> claimResponseItems = wrappedResponse.getItems();
+        List<InsuranceClaimItem> claimItems = wrapResponse(claim).getItems();
+
+        for (int itemIndex = 0; itemIndex < claimResponseItems.size(); itemIndex++) {
+            InsuranceClaimItem nextItem = claimResponseItems.get(itemIndex);
+            InsuranceClaimItem itemAdditionalData = claimItems.get(itemIndex);
+            addDataFromClaimItemToClaimResponseItem(nextItem, itemAdditionalData);
+        }
+        return wrappedResponse;
+    }
+
+    private void addDataFromClaimItemToClaimResponseItem(InsuranceClaimItem claimResponseItem, InsuranceClaimItem claimItem) {
+        claimResponseItem.setItem(claimItem.getItem());
+        claimResponseItem.setQuantityProvided(claimItem.getQuantityProvided());
     }
 }

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/request/impl/ExternalApiRequestImpl.java
@@ -1,6 +1,5 @@
 package org.openmrs.module.insuranceclaims.api.service.request.impl;
 
-import javassist.NotFoundException;
 import org.hl7.fhir.dstu3.model.Claim;
 import org.hl7.fhir.dstu3.model.ClaimResponse;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -13,12 +12,13 @@ import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
 import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimItemService;
 import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimService;
 import org.openmrs.module.insuranceclaims.api.service.db.ItemDbService;
+import org.openmrs.module.insuranceclaims.api.service.exceptions.ClaimRequestException;
+import org.openmrs.module.insuranceclaims.api.service.exceptions.ItemMatchingFailedException;
 import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimDiagnosisService;
 import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimItemService;
 import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRClaimResponseService;
 import org.openmrs.module.insuranceclaims.api.service.fhir.FHIRInsuranceClaimService;
 import org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimUtil;
-import org.openmrs.module.insuranceclaims.api.service.request.ClaimRequestException;
 import org.openmrs.module.insuranceclaims.api.service.request.ExternalApiRequest;
 import org.springframework.web.client.HttpServerErrorException;
 
@@ -102,7 +102,7 @@ public class ExternalApiRequestImpl implements ExternalApiRequest {
             insuranceClaimItemService.updateInsuranceClaimItems(omrsItems, wrappedResponse.getItems());
 
             return claim;
-        } catch (URISyntaxException | FHIRException | NotFoundException requestException) {
+        } catch (URISyntaxException | FHIRException | ItemMatchingFailedException requestException) {
             String exceptionMessage = "Exception occured during processing request: "
                     + "Message:" + requestException.getMessage();
             throw new ClaimRequestException(exceptionMessage, requestException);

--- a/api/src/main/resources/components/clientComponents.xml
+++ b/api/src/main/resources/components/clientComponents.xml
@@ -24,5 +24,7 @@
         <property name="fhirClaimDiagnosisService" ref="insuranceclaims.FHIRClaimDiagnosisService"/>
         <property name="fhirClaimItemService"      ref="insuranceclaims.FHIRClaimItemService"/>
         <property name="insuranceClaimService"     ref="insuranceclaims.InsuranceClaimService"/>
+        <property name="insuranceClaimItemService" ref="insuranceclaims.InsuranceClaimItemService"/>
+        <property name="itemDbService"             ref="insuranceclaims.ItemDbService"/>
     </bean>
 </beans>

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/InsuranceClaimServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/InsuranceClaimServiceTest.java
@@ -1,5 +1,7 @@
 package org.openmrs.module.insuranceclaims.api.service;
 
+import javassist.NotFoundException;
+import org.apache.commons.lang.time.DateUtils;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -12,6 +14,8 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimDiagnosis;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItemStatus;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimStatus;
 import org.openmrs.module.insuranceclaims.api.mother.InsuranceClaimDiagnosisMother;
 import org.openmrs.module.insuranceclaims.api.mother.InsuranceClaimItemMother;
 import org.openmrs.module.insuranceclaims.api.mother.InsuranceClaimMother;
@@ -19,14 +23,30 @@ import org.openmrs.module.insuranceclaims.api.util.TestConstants;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.openmrs.module.insuranceclaims.api.util.TestConstants.INSURANCE_CLAIM_TEST_ITEM_CONCEPT_DATASET;
 
 /**
  * This is an integration test (extends BaseModuleContextSensitiveTest), which verifies logic in InsuranceClaimService.
  */
 public class InsuranceClaimServiceTest extends BaseModuleContextSensitiveTest {
+
+	private static final String UPDATED_ADJUSTMENT = "UpdatedAdjustment";
+	private static final BigDecimal UPDATED_APPROVED_TOTAL = new BigDecimal("123.45");
+	private static final String[] DATE_FORMATS = {"yyyy-mm-dd"};
+	private static final String UPDATED_DATE = "2034-10-10";
+	private static final String UPDATED_REJECTION_REASON = "UpdatedRejectionReason";
+	private static final int UPDATED_QUANTITY_APPROVED = 19;
+	private static final InsuranceClaimItemStatus UPDATED_CLAIM_ITEM_STATUS = InsuranceClaimItemStatus.REJECTED;
+
+	private static final InsuranceClaimStatus UPDATED_STATUS = InsuranceClaimStatus.REJECTED;
 
 	@Autowired
 	private InsuranceClaimService insuranceClaimService;
@@ -36,6 +56,9 @@ public class InsuranceClaimServiceTest extends BaseModuleContextSensitiveTest {
 
 	@Autowired
 	private InsuranceClaimDiagnosisService insuranceClaimDiagnosisService;
+
+	@Autowired
+	private ProvidedItemService providedItemService;
 
 	@Test
 	public void saveInsuranceClaim_shouldCorrectlySaveClaim() {
@@ -68,7 +91,7 @@ public class InsuranceClaimServiceTest extends BaseModuleContextSensitiveTest {
 	}
 
 	@Test
-	public void saveClaimItem_shouldCorrectlySaveClaim() {
+	public void saveClaimItem_shouldCorrectlySaveClaim() throws Exception {
 		InsuranceClaimItem item = createTestClaimItem();
 		insuranceClaimItemService.saveOrUpdate(item);
 		InsuranceClaimItem savedClaim = insuranceClaimItemService.getByUuid(item.getUuid());
@@ -97,6 +120,67 @@ public class InsuranceClaimServiceTest extends BaseModuleContextSensitiveTest {
 		Assert.assertThat(service, is(notNullValue()));
 	}
 
+	@Test
+	public void updateClaim_shouldUpdateCorrectFields() throws ParseException {
+		InsuranceClaim claimWithUpdates = createClaimWithUpdates();
+		InsuranceClaim toBeUpdated = createTestClaim();
+
+		InsuranceClaim updatedClaim = insuranceClaimService.updateClaim(toBeUpdated, claimWithUpdates);
+		Assert.assertThat(updatedClaim.getAdjustment(), Matchers.equalTo(claimWithUpdates.getAdjustment()));
+		Assert.assertThat(updatedClaim.getApprovedTotal(), Matchers.equalTo(claimWithUpdates.getApprovedTotal()));
+		Assert.assertThat(updatedClaim.getDateProcessed(), Matchers.equalTo(claimWithUpdates.getDateProcessed()));
+		Assert.assertThat(updatedClaim.getRejectionReason(), Matchers.equalTo(claimWithUpdates.getRejectionReason()));
+		Assert.assertThat(updatedClaim.getStatus(), Matchers.equalTo(claimWithUpdates.getStatus()));
+	}
+
+	@Test
+	public void updateInsuranceClaimItem_shouldUpdateCorrectFields() throws Exception {
+		InsuranceClaimItem toBeUpdated = createTestClaimItem();
+		InsuranceClaimItem itemWithUpdates = createClaimItemWithUpdates();
+
+		InsuranceClaimItem updatedItem = insuranceClaimItemService.updateInsuranceClaimItem(toBeUpdated, itemWithUpdates);
+		Assert.assertThat(updatedItem.getJustification(), Matchers.equalTo(itemWithUpdates.getJustification()));
+		Assert.assertThat(updatedItem.getStatus(), Matchers.equalTo(itemWithUpdates.getStatus()));
+		Assert.assertThat(updatedItem.getQuantityApproved(), Matchers.equalTo(itemWithUpdates.getQuantityApproved()));
+		Assert.assertThat(updatedItem.getRejectionReason(), Matchers.equalTo(itemWithUpdates.getRejectionReason()));
+	}
+
+	@Test
+	public void updateInsuranceClaimItems_shouldMatchAndUpdateItems() throws Exception {
+		InsuranceClaimItem toBeUpdated = createTestClaimItem();
+		InsuranceClaimItem itemWithUpdates = createClaimItemWithUpdates();
+		insuranceClaimItemService.saveOrUpdate(toBeUpdated);
+		insuranceClaimItemService.saveOrUpdate(itemWithUpdates);
+		List<InsuranceClaimItem> listOfItemsToUpdate = Arrays.asList(toBeUpdated);
+		List<InsuranceClaimItem> listOfItemsWithUpdate = Arrays.asList(itemWithUpdates);
+
+		List<InsuranceClaimItem> updatedItems =
+				insuranceClaimItemService.updateInsuranceClaimItems(listOfItemsToUpdate, listOfItemsWithUpdate);
+
+		Assert.assertThat(updatedItems, Matchers.hasSize(1));
+		InsuranceClaimItem updatedItem = updatedItems.get(0);
+		Assert.assertThat(updatedItem.getJustification(), Matchers.equalTo(itemWithUpdates.getJustification()));
+		Assert.assertThat(updatedItem.getStatus(), Matchers.equalTo(itemWithUpdates.getStatus()));
+		Assert.assertThat(updatedItem.getQuantityApproved(), Matchers.equalTo(itemWithUpdates.getQuantityApproved()));
+		Assert.assertThat(updatedItem.getRejectionReason(), Matchers.equalTo(itemWithUpdates.getRejectionReason()));
+	}
+
+	@Test(expected = NotFoundException.class)
+	public void updateInsuranceClaimItems_invalidUpdateItemsShouldThrowException() throws Exception {
+		InsuranceClaimItem toBeUpdated = createTestClaimItem();
+		InsuranceClaimItem itemWithUpdates = createClaimItemWithUpdates();
+		Concept notMatchingConcept = Context.getConceptService().getConceptByUuid("160148BAAAAAAAAAAAAAAAAAAAAAAAAAABBB");
+
+		itemWithUpdates.getItem().setItem(notMatchingConcept);
+		insuranceClaimItemService.saveOrUpdate(toBeUpdated);
+		providedItemService.saveOrUpdate(itemWithUpdates.getItem());
+		insuranceClaimItemService.saveOrUpdate(itemWithUpdates);
+		List<InsuranceClaimItem> listOfItemsToUpdate = Arrays.asList(toBeUpdated);
+		List<InsuranceClaimItem> listOfItemsWithUpdate = Arrays.asList(itemWithUpdates);
+
+		insuranceClaimItemService.updateInsuranceClaimItems(listOfItemsToUpdate, listOfItemsWithUpdate);
+	}
+
 	private InsuranceClaim createTestClaim() {
 		Location location = Context.getLocationService().getLocation(TestConstants.TEST_LOCATION_ID);
 		Provider provider = Context.getProviderService().getProvider(TestConstants.TEST_PROVIDER_ID);
@@ -106,8 +190,10 @@ public class InsuranceClaimServiceTest extends BaseModuleContextSensitiveTest {
 		return InsuranceClaimMother.createTestInstance(location, provider, visitType, identifierType);
 	}
 
-	private InsuranceClaimItem createTestClaimItem() {
-		Concept concept = Context.getConceptService().getConcept(TestConstants.TEST_CONCEPT_ID);
+	private InsuranceClaimItem createTestClaimItem() throws Exception {
+		executeDataSet(INSURANCE_CLAIM_TEST_ITEM_CONCEPT_DATASET);
+		Concept concept = Context.getConceptService().getConceptByUuid("160148BAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+
 		InsuranceClaim claim = createTestClaim();
 		return InsuranceClaimItemMother.createTestInstance(concept, claim);
 	}
@@ -116,5 +202,26 @@ public class InsuranceClaimServiceTest extends BaseModuleContextSensitiveTest {
 		Concept concept = Context.getConceptService().getConcept(TestConstants.TEST_CONCEPT_ID);
 		InsuranceClaim claim = createTestClaim();
 		return InsuranceClaimDiagnosisMother.createTestInstance(concept, claim);
+	}
+
+	private InsuranceClaim createClaimWithUpdates() throws ParseException {
+		InsuranceClaim insuranceClaim = new InsuranceClaim();
+		insuranceClaim.setAdjustment(UPDATED_ADJUSTMENT);
+		insuranceClaim.setApprovedTotal(UPDATED_APPROVED_TOTAL);
+		insuranceClaim.setDateProcessed(DateUtils.parseDate(UPDATED_DATE, DATE_FORMATS));
+		insuranceClaim.setRejectionReason(UPDATED_REJECTION_REASON);
+		insuranceClaim.setStatus(UPDATED_STATUS);
+
+		return insuranceClaim;
+	}
+
+	private InsuranceClaimItem createClaimItemWithUpdates() throws Exception {
+		InsuranceClaimItem insuranceClaimItem = createTestClaimItem();
+		insuranceClaimItem.setQuantityApproved(UPDATED_QUANTITY_APPROVED);
+		insuranceClaimItem.setStatus(UPDATED_CLAIM_ITEM_STATUS);
+		insuranceClaimItem.setJustification(UPDATED_ADJUSTMENT);
+		insuranceClaimItem.setRejectionReason(UPDATED_REJECTION_REASON);
+
+		return insuranceClaimItem;
 	}
 }

--- a/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/InsuranceClaimServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/insuranceclaims/api/service/InsuranceClaimServiceTest.java
@@ -1,6 +1,5 @@
 package org.openmrs.module.insuranceclaims.api.service;
 
-import javassist.NotFoundException;
 import org.apache.commons.lang.time.DateUtils;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -19,6 +18,7 @@ import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimStatus;
 import org.openmrs.module.insuranceclaims.api.mother.InsuranceClaimDiagnosisMother;
 import org.openmrs.module.insuranceclaims.api.mother.InsuranceClaimItemMother;
 import org.openmrs.module.insuranceclaims.api.mother.InsuranceClaimMother;
+import org.openmrs.module.insuranceclaims.api.service.exceptions.ItemMatchingFailedException;
 import org.openmrs.module.insuranceclaims.api.util.TestConstants;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -165,7 +165,7 @@ public class InsuranceClaimServiceTest extends BaseModuleContextSensitiveTest {
 		Assert.assertThat(updatedItem.getRejectionReason(), Matchers.equalTo(itemWithUpdates.getRejectionReason()));
 	}
 
-	@Test(expected = NotFoundException.class)
+	@Test(expected = ItemMatchingFailedException.class)
 	public void updateInsuranceClaimItems_invalidUpdateItemsShouldThrowException() throws Exception {
 		InsuranceClaimItem toBeUpdated = createTestClaimItem();
 		InsuranceClaimItem itemWithUpdates = createClaimItemWithUpdates();

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.net.URISyntaxException;
 
 import static org.openmrs.module.insuranceclaims.InsuranceClaimsOmodConstants.CLAIM_ALREADY_SENT_MESSAGE;
+import static org.openmrs.module.insuranceclaims.InsuranceClaimsOmodConstants.CLAIM_NOT_SENT_MESSAGE;
 
 @RestController
 @RequestMapping(value = "insuranceclaims/rest/v1/claims")
@@ -92,6 +93,35 @@ public class InsuranceClaimResourceController {
              requestResponse = new ResponseEntity<>(wrapper, HttpStatus.ACCEPTED);
         } catch (URISyntaxException wrongUrl) {
              requestResponse = new ResponseEntity<>(wrongUrl.getMessage(), HttpStatus.EXPECTATION_FAILED);
+        }
+
+        return requestResponse;
+    }
+
+    /**
+     * @param claimUuid uuid claim which have to be updated witch external server values
+     * @return InsuranceClaim with updated values
+     *
+     * It uses insurance claim external api to receive ClaimResponse information from external source and then use it to
+     * to update this proper values related to this insurance claim (I.e. check if was claim was valuated, check which claim
+     * items were approved).
+     */
+    @RequestMapping(value = "updateC/updateClaim", method = RequestMethod.GET, produces = "application/json")
+    @ResponseBody
+    public ResponseEntity updateClaim(@RequestParam(value = "claimUuid") String claimUuid,
+                                      HttpServletRequest request, HttpServletResponse response) {
+        InsuranceClaim claim = insuranceClaimService.getByUuid(claimUuid);
+
+        if (claim.getExternalId() == null) {
+            return ResponseEntity.badRequest().body(CLAIM_NOT_SENT_MESSAGE);
+        }
+
+        ResponseEntity requestResponse;
+        try {
+            InsuranceClaim wrapper = externalApiRequest.updateClaim(claim);
+            requestResponse =  new ResponseEntity<>(wrapper, HttpStatus.ACCEPTED);
+        } catch (ClaimRequestException e) {
+            requestResponse =  new ResponseEntity<>(e.getMessage(), HttpStatus.EXPECTATION_FAILED);
         }
 
         return requestResponse;

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
@@ -99,12 +99,11 @@ public class InsuranceClaimResourceController {
     }
 
     /**
-     * @param claimUuid uuid claim which have to be updated witch external server values
-     * @return InsuranceClaim with updated values
-     *
-     * It uses insurance claim external api to receive ClaimResponse information from external source and then use it to
+     * Uses insurance claim external api to receive ClaimResponse information and then use it to
      * to update this proper values related to this insurance claim (I.e. check if was claim was valuated, check which claim
      * items were approved).
+     * @param claimUuid uuid claim which have to be updated witch external server values
+     * @return InsuranceClaim with updated values
      */
     @RequestMapping(value = "updateC/updateClaim", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
@@ -3,7 +3,7 @@ package org.openmrs.module.insuranceclaims.web.controller;
 import org.openmrs.module.insuranceclaims.api.client.impl.ClaimRequestWrapper;
 import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
 import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimService;
-import org.openmrs.module.insuranceclaims.api.service.request.ClaimRequestException;
+import org.openmrs.module.insuranceclaims.api.service.exceptions.ClaimRequestException;
 import org.openmrs.module.insuranceclaims.api.service.request.ExternalApiRequest;
 import org.openmrs.module.insuranceclaims.forms.ClaimFormService;
 import org.openmrs.module.insuranceclaims.forms.NewClaimForm;


### PR DESCRIPTION
### SUMMARY
This PR adds functionality that allow user to update status of claim. 
Claim is updated with information received from ClaimResponse endpoint in external service. 
Endpoint URI:
`openmrs/ws/insuranceclaims/rest/v1/claims/updateClaim?claimUuid={uuid}`

TICKET: [ICLM-32](https://issues.openmrs.org/browse/ICLM-32) 