### PR TITLE
ICLM-33: Created view for claim details

### DIFF
--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/exceptions/EligibilityRequestException.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/exceptions/EligibilityRequestException.java
@@ -1,4 +1,0 @@
-package org.openmrs.module.insuranceclaims.api.service.exceptions;
-
-public class EligibilityRequestException {
-}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/exceptions/EligibilityRequestException.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/exceptions/EligibilityRequestException.java
@@ -1,0 +1,4 @@
+package org.openmrs.module.insuranceclaims.api.service.exceptions;
+
+public class EligibilityRequestException {
+}

--- a/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimConstants.java
+++ b/api/src/main/java/org/openmrs/module/insuranceclaims/api/service/fhir/util/InsuranceClaimConstants.java
@@ -46,6 +46,8 @@ public final class InsuranceClaimConstants {
     public static final String CONTRACT = "Contract";
     public static final int CONTRACT_POLICY_ID_ORDINAL = 1;
     public static final int CONTRACT_EXPIRE_DATE_ORDINAL = 2;
+
+    public static final String EXPECTED_DATE_PATTERN = "yyyy-mm-dd";
     public static final List<String> CONTRACT_DATE_PATTERN = Collections.unmodifiableList(
             Arrays.asList("yyyy-mm-dd hh:mm:ss", "yyyy-mm-dd"));
 

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/ClaimUtils.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/ClaimUtils.java
@@ -32,7 +32,7 @@ public final class ClaimUtils {
         return itemMapping;
     }
 
-    private static String buildItemName(ProvidedItem item) {
+    public static String buildItemName(ProvidedItem item) {
         String name = item.getItem() != null ? getConceptName(item.getItem()) : null;
         if (name != null) {
             name = buildKnownProvidedItemName(item);

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ClaimFormBuilder.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ClaimFormBuilder.java
@@ -1,0 +1,6 @@
+package org.openmrs.module.insuranceclaims.forms;
+
+public interface ClaimFormBuilder {
+
+    ValuatedClaimForm generateClaimForm(String claimUuid);
+}

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimDiagnosis.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimDiagnosis.java
@@ -27,5 +27,4 @@ public class ValuatedClaimDiagnosis {
     public void setDiagnosisUuid(String diagnosisUuid) {
         this.diagnosisUuid = diagnosisUuid;
     }
-
 }

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimDiagnosis.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimDiagnosis.java
@@ -1,0 +1,31 @@
+package org.openmrs.module.insuranceclaims.forms;
+
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimDiagnosis;
+
+public class ValuatedClaimDiagnosis {
+    private String diagnosisName;
+    private String diagnosisUuid;
+
+    public ValuatedClaimDiagnosis() {}
+
+    public ValuatedClaimDiagnosis(InsuranceClaimDiagnosis diagnosis) {
+        this.diagnosisName = diagnosis.getConcept().getName().getName();
+        this.diagnosisUuid = diagnosis.getUuid();
+    }
+    public void setDiagnosisName(String diagnosisName) {
+        this.diagnosisName = diagnosisName;
+    }
+
+    public String getDiagnosisName() {
+        return diagnosisName;
+    }
+
+    public String getDiagnosisUuid() {
+        return diagnosisUuid;
+    }
+
+    public void setDiagnosisUuid(String diagnosisUuid) {
+        this.diagnosisUuid = diagnosisUuid;
+    }
+
+}

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimForm.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimForm.java
@@ -50,5 +50,4 @@ public class ValuatedClaimForm extends NewClaimForm {
     public void setClaim(InsuranceClaim claim) {
         this.claim = claim;
     }
-
 }

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimForm.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimForm.java
@@ -1,0 +1,54 @@
+package org.openmrs.module.insuranceclaims.forms;
+
+import ca.uhn.fhir.util.DateUtils;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+
+import java.util.List;
+
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.EXPECTED_DATE_PATTERN;
+
+public class ValuatedClaimForm extends NewClaimForm {
+    private List<ValuatedClaimItem> claimItems;
+    private List<ValuatedClaimDiagnosis> claimDiagnoses;
+    private InsuranceClaim claim;
+
+    public ValuatedClaimForm(InsuranceClaim claim) {
+        this.claim = claim;
+        setClaimCode(claim.getClaimCode());
+        setClaimExplanation(claim.getExplanation());
+        setClaimJustification(claim.getAdjustment());
+        setStartDate(DateUtils.formatDate(claim.getDateFrom(), EXPECTED_DATE_PATTERN));
+        setEndDate(DateUtils.formatDate(claim.getDateTo(), EXPECTED_DATE_PATTERN));
+        setLocation(claim.getLocation().getId().toString());
+
+        setPaidInFacility(false);
+        setPatient(claim.getPatient().getId().toString());
+        setVisitType(claim.getVisitType().getName());
+        setGuaranteeId(claim.getGuaranteeId());
+        setProvider(claim.getProvider().getUuid());
+    }
+    public void setClaimItems(List<ValuatedClaimItem> claimItems) {
+        this.claimItems = claimItems;
+    }
+
+    public List<ValuatedClaimItem> getClaimItems() {
+        return claimItems;
+    }
+
+    public void setClaimDiagnoses(List<ValuatedClaimDiagnosis> claimDiagnoses) {
+        this.claimDiagnoses = claimDiagnoses;
+    }
+
+    public List<ValuatedClaimDiagnosis> getClaimDiagnoses() {
+        return claimDiagnoses;
+    }
+
+    public InsuranceClaim getClaim() {
+        return claim;
+    }
+
+    public void setClaim(InsuranceClaim claim) {
+        this.claim = claim;
+    }
+
+}

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimItem.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimItem.java
@@ -58,5 +58,4 @@ public class ValuatedClaimItem {
     public String getExplanation() {
         return this.explanation;
     }
-
 }

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimItem.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/ValuatedClaimItem.java
@@ -1,0 +1,62 @@
+package org.openmrs.module.insuranceclaims.forms;
+
+import ca.uhn.fhir.util.DateUtils;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
+
+import static org.openmrs.module.insuranceclaims.ClaimUtils.buildItemName;
+import static org.openmrs.module.insuranceclaims.api.service.fhir.util.InsuranceClaimConstants.EXPECTED_DATE_PATTERN;
+
+public class ValuatedClaimItem {
+    private String itemName;
+    private String itemUuid;
+    private String dateServed;
+    private String explanation;
+    private InsuranceClaimItem item;
+
+    public ValuatedClaimItem() {}
+
+    public ValuatedClaimItem(InsuranceClaimItem item) {
+        this.item = item;
+        this.itemName = buildItemName(item.getItem());
+        this.itemUuid = item.getUuid();
+        this.explanation = item.getExplanation();
+        this.dateServed = DateUtils.formatDate(item.getItem().getDateOfServed(), EXPECTED_DATE_PATTERN);
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public String getItemUuid() {
+        return itemUuid;
+    }
+
+    public void setItemUuid(String itemUuid) {
+        this.itemUuid = itemUuid;
+    }
+
+    public void setDateServed(String dateServed) {
+        this.dateServed = dateServed;
+    }
+
+    public String getDateServed() {
+        return dateServed;
+    }
+
+    public InsuranceClaimItem getItem() {
+        return this.item;
+    }
+
+    public void setExplanation(String explanation) {
+        this.explanation = explanation;
+    }
+
+    public String getExplanation() {
+        return this.explanation;
+    }
+
+}

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/impl/ClaimFormBuilderImpl.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/impl/ClaimFormBuilderImpl.java
@@ -1,0 +1,55 @@
+package org.openmrs.module.insuranceclaims.forms.impl;
+
+
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaim;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimDiagnosis;
+import org.openmrs.module.insuranceclaims.api.model.InsuranceClaimItem;
+import org.openmrs.module.insuranceclaims.api.service.InsuranceClaimService;
+import org.openmrs.module.insuranceclaims.api.service.db.DiagnosisDbService;
+import org.openmrs.module.insuranceclaims.api.service.db.ItemDbService;
+import org.openmrs.module.insuranceclaims.forms.ClaimFormBuilder;
+import org.openmrs.module.insuranceclaims.forms.ValuatedClaimDiagnosis;
+import org.openmrs.module.insuranceclaims.forms.ValuatedClaimForm;
+import org.openmrs.module.insuranceclaims.forms.ValuatedClaimItem;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ClaimFormBuilderImpl implements ClaimFormBuilder {
+
+    @Autowired
+    InsuranceClaimService insuranceClaimService;
+
+    @Autowired
+    ItemDbService itemDbService;
+
+    @Autowired
+    DiagnosisDbService diagnosisDbService;
+
+    @Override
+    public ValuatedClaimForm generateClaimForm(String claimUuid) {
+        InsuranceClaim claim = insuranceClaimService.getByUuid(claimUuid);
+        ValuatedClaimForm form = new ValuatedClaimForm(claim);
+        List<InsuranceClaimItem> items = itemDbService.findInsuranceClaimItems(claim.getId());
+        form.setClaimItems(buildClaimItems(items));
+        List<InsuranceClaimDiagnosis> diagnoses =  diagnosisDbService.findInsuranceClaimDiagnosis(claim.getId());
+        form.setClaimDiagnoses(buildDiagnosisComponent(diagnoses));
+
+        return form;
+    }
+
+    private List<ValuatedClaimItem> buildClaimItems(List<InsuranceClaimItem> claimItems) {
+        return claimItems.stream()
+                .map(item -> new ValuatedClaimItem(item))
+                .collect(Collectors.toList());
+    }
+
+    private List<ValuatedClaimDiagnosis> buildDiagnosisComponent(List<InsuranceClaimDiagnosis> claimDiagnoses) {
+        return claimDiagnoses.stream()
+                .map(diagnosis -> new ValuatedClaimDiagnosis(diagnosis))
+                .collect(Collectors.toList());
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/impl/ClaimFormBuilderImpl.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/impl/ClaimFormBuilderImpl.java
@@ -17,11 +17,11 @@ import java.util.stream.Collectors;
 
 public class ClaimFormBuilderImpl implements ClaimFormBuilder {
 
-    InsuranceClaimService insuranceClaimService;
+    private InsuranceClaimService insuranceClaimService;
 
-    ItemDbService itemDbService;
+    private ItemDbService itemDbService;
 
-    DiagnosisDbService diagnosisDbService;
+    private DiagnosisDbService diagnosisDbService;
 
     @Override
     public ValuatedClaimForm generateClaimForm(String claimUuid) {

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/impl/ClaimFormBuilderImpl.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/forms/impl/ClaimFormBuilderImpl.java
@@ -11,22 +11,16 @@ import org.openmrs.module.insuranceclaims.forms.ClaimFormBuilder;
 import org.openmrs.module.insuranceclaims.forms.ValuatedClaimDiagnosis;
 import org.openmrs.module.insuranceclaims.forms.ValuatedClaimForm;
 import org.openmrs.module.insuranceclaims.forms.ValuatedClaimItem;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Service
 public class ClaimFormBuilderImpl implements ClaimFormBuilder {
 
-    @Autowired
     InsuranceClaimService insuranceClaimService;
 
-    @Autowired
     ItemDbService itemDbService;
 
-    @Autowired
     DiagnosisDbService diagnosisDbService;
 
     @Override
@@ -39,6 +33,18 @@ public class ClaimFormBuilderImpl implements ClaimFormBuilder {
         form.setClaimDiagnoses(buildDiagnosisComponent(diagnoses));
 
         return form;
+    }
+
+    public void setInsuranceClaimService(InsuranceClaimService insuranceClaimService) {
+        this.insuranceClaimService = insuranceClaimService;
+    }
+
+    public void setItemDbService(ItemDbService itemDbService) {
+        this.itemDbService = itemDbService;
+    }
+
+    public void setDiagnosisDbService(DiagnosisDbService diagnosisDbService) {
+        this.diagnosisDbService = diagnosisDbService;
     }
 
     private List<ValuatedClaimItem> buildClaimItems(List<InsuranceClaimItem> claimItems) {

--- a/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
+++ b/omod/src/main/java/org/openmrs/module/insuranceclaims/web/controller/InsuranceClaimResourceController.java
@@ -105,7 +105,7 @@ public class InsuranceClaimResourceController {
      * @param claimUuid uuid claim which have to be updated witch external server values
      * @return InsuranceClaim with updated values
      */
-    @RequestMapping(value = "updateC/updateClaim", method = RequestMethod.GET, produces = "application/json")
+    @RequestMapping(value = "/updateClaim", method = RequestMethod.GET, produces = "application/json")
     @ResponseBody
     public ResponseEntity updateClaim(@RequestParam(value = "claimUuid") String claimUuid,
                                       HttpServletRequest request, HttpServletResponse response) {

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -21,4 +21,11 @@
         <property name="insuranceClaimItemService" ref="insuranceclaims.InsuranceClaimItemService"/>
         <property name="insuranceClaimDiagnosisService" ref="insuranceclaims.InsuranceClaimDiagnosisService"/>
     </bean>
+
+    <bean id="insuranceclaims.ClaimFormBuilder"
+          class="org.openmrs.module.insuranceclaims.forms.impl.ClaimFormBuilderImpl">
+        <property name="insuranceClaimService" ref="insuranceclaims.InsuranceClaimService"/>
+        <property name="itemDbService" ref="insuranceclaims.ItemDbService"/>
+        <property name="diagnosisDbService" ref="insuranceclaims.DiagnosisDbService"/>
+    </bean>
 </beans>


### PR DESCRIPTION
### SUMMARY

1. Added singleClaimView page, depending on the parameters, it displays a view of adding a new claim or displays details of an already created one.
2. Template for adding new claims was changed:
    * Button 'Whats in provided items' was removed.
    * Input fields for item and claim justification were removed, their value must be obtained from the external system.
3. Endpoint for updating claim was changed from "updateC/updateClaim" to "/updateClaim"
 
TICKET: [ICLM-33](https://issues.openmrs.org/browse/ICLM-33)